### PR TITLE
Try to clarify the iOS build instructions a bit

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,7 +45,7 @@ type = "type"
   showLanguageSwitcher = false
 
   # Custom CSS and JS. Relative to /static/css and /static/js respectively.
-  customCSS = ["buttons.css", "anim.css", "header.css", "dropdown.css", "sidebar.css"]
+  customCSS = ["buttons.css", "anim.css", "header.css", "dropdown.css", "sidebar.css", "post-content.css"]
   customJS = []
 
   [params.social]

--- a/content/post/build-code-ios.md
+++ b/content/post/build-code-ios.md
@@ -20,7 +20,7 @@ Are you familiar with iOS development environment and interested to learn more w
 <!--more-->
 # How to build the iOS app:
 
-## 1) Build the LibreOffice core code
+## 1) Build the LibreOffice core code (on a Mac)
 
 First you need to build the LibreOffice core code for iOS. Put in your autogen.input something like this:
 
@@ -35,12 +35,17 @@ and build "normally". (Naturally, no unit tests will be run when cross-compiling
 
 This will produce a large number of static archives (.a) here and there in instdir and workdir, but no app that can be run as such. (You can see a list of them in workdir/CustomTarget/ios/ios-all-static-libs.list)
 
-## 2) Build COOL Dependencies
+## 2) Build COOL Dependencies (on a Mac)
 
 POCO LIBRARY
 
-2.1) Get the source poco library at https://pocoproject.org/download.html
-2.2) Unpack
+2.1) The below instructions are for the so-called basic edition of
+POCO 1.10.1. (If there has been a newer release of POCO by the time
+you read this, adapt as necessary.) Get the POCO library source code
+from https://pocoproject.org/releases/poco-1.10.1/ , the
+poco-1.10.1.tar.gz archive.
+
+2.2) Unpack in some suitable location.
 
 2.3) Compile
 ```bash
@@ -54,11 +59,6 @@ make POCO_TARGET_OSARCH=arm64 install
 ```
 
 This will install the poco static libraries and headers to your $home directory into poco-ios-arm64 directory. You can change the directory to your wishes, but by installing it this way into a directory in `$HOME` it doesn't pollute your root directories, doesn't need root permissions and can be removed easily.
-
-If compiler can't find `<string.h>` you need to install:
-```bash
-open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
-```
 
 ## 3) Clone Online on a Mac
 Do a separate clone of the online repo on macOS, but don't do any autogen.sh, configure, or make, or open the Mobile Xcode project there yet. We call this the app folder.

--- a/content/post/build-code-ios.md
+++ b/content/post/build-code-ios.md
@@ -82,11 +82,11 @@ make clean && make && tar cf - loleaflet/dist | ssh misan.local 'cd lo/online-io
 
 where `misan.local` is the macOS machine where I build the app, and `~/lo/online-ios-device` is the app folder from step 2.
 
-Then back to the Mac:
+## 5) Building for iOS
+### on a Mac ## {#ios-5-clone-online-mac .extraclass class="requirement-machine"}
+Now back to your Mac, and with LibreOffice built from step 1, you must already have GNU autoconf installed on the Mac. Install also GNU automake and libtool. Preferably from sources, to make sure a potential installation of brew or similar will not pollute your environment with unknown stuff.
 
-As you were able to build LibreOffice in step 1, you must already have GNU autoconf installed on the Mac. Install also GNU automake and libtool. Preferably from sources, to make sure a potential installation of brew or similar will not pollute your environment with unknown stuff.
-
-As GNU libtool will be needed only for a very minimal part of the build (running the autogen.sh script, but not anything else), it's safest to install it somewhere that is not in your $PATH. Let's say `/opt/libtool`. (Installing Automake in the default `/usr/local`, which is in `$PATH`, is less risky.)
+As GNU libtool will be needed only for a very minimal part of the build (running the `autogen.sh` script, but not anything else), it's safest to install it somewhere that is not in your $PATH. Let's say `/opt/libtool`. (Installing Automake in the default `/usr/local`, which is in `$PATH`, is less risky.)
 
 Run the autogen.sh script in the app folder, with GNU libtool available, for instance:
 
@@ -94,21 +94,21 @@ Run the autogen.sh script in the app folder, with GNU libtool available, for ins
 PATH=/opt/libtool/bin:$PATH ./autogen.sh
 ```
 
-5) In the app folder from step 2, edit the ios/Mobile.xcodeproj/project.pbxproj file in your favourite text editor. Change LOSRCDIR and all instances of "../ios-device" to refer the the LibreOffice core source directory from step 1.
+5.1) In the app folder from step 2, edit the `ios/Mobile.xcodeproj/project.pbxproj` file in your favourite text editor. Change `LOSRCDIR` and all instances of `../ios-device` to refer the the LibreOffice core source directory from step 1.
 
-6) In the app folder, run:
+5.2) In the app folder, run:
 
 ```bash
 ./configure --enable-iosapp --with-app-name="My Own Mobile Office Suite" --with-lo-builddir=$HOME/lode/dev/LO --with-poco-includes=$HOME/poco-ios-arm64/include --with-poco-libs=$HOME/poco-ios-arm64/lib
 ```
 
-The configure script puts the app name as the CFBundleDisplayName property into the ios/Mobile/Info.plist file, and sets up some symbolic links that point to the LibreOffice core source and build directories (which typically will be the same, of course).
+The configure script puts the app name as the `CFBundleDisplayName` property into the `ios/Mobile/Info.plist` file, and sets up some symbolic links that point to the LibreOffice core source and build directories (which typically will be the same, of course).
 
-7) Before opening the Xcode project for the first time
+5.3) Before opening the Xcode project for the first time
    - seriously consider disabling source code indexing, this
    spawns a vast number of git processes, and consumes huge
    amounts of CPU & memory:
 
-	`Xcode -> Preferences, "Source Control", uncheck "Enable Source Control"`
+	Xcode -> Preferences, "Source Control", uncheck "Enable Source Control"
 
-8) Now you can open the Mobile Xcode project, build it, and run it.
+5.4) Now you can open the Mobile Xcode project, build it, and run it.

--- a/content/post/build-code-ios.md
+++ b/content/post/build-code-ios.md
@@ -20,7 +20,8 @@ Are you familiar with iOS development environment and interested to learn more w
 <!--more-->
 # How to build the iOS app:
 
-## 1) Build the LibreOffice core code (on a Mac)
+## 1) Build the LibreOffice core code
+### on a Mac ## {#ios-1-build-Lo-mac .extraclass class="requirement-machine"}
 
 First you need to build the LibreOffice core code for iOS. Put in your autogen.input something like this:
 
@@ -35,7 +36,8 @@ and build "normally". (Naturally, no unit tests will be run when cross-compiling
 
 This will produce a large number of static archives (.a) here and there in instdir and workdir, but no app that can be run as such. (You can see a list of them in workdir/CustomTarget/ios/ios-all-static-libs.list)
 
-## 2) Build COOL Dependencies (on a Mac)
+## 2) Build COOL Dependencies
+### on a Mac ## {#ios-2-build-cool-mac .extraclass class="requirement-machine"}
 
 POCO LIBRARY
 
@@ -60,10 +62,12 @@ make POCO_TARGET_OSARCH=arm64 install
 
 This will install the poco static libraries and headers to your $home directory into poco-ios-arm64 directory. You can change the directory to your wishes, but by installing it this way into a directory in `$HOME` it doesn't pollute your root directories, doesn't need root permissions and can be removed easily.
 
-## 3) Clone Online on a Mac
+## 3) Clone Online
+### on a Mac ## {#ios-3-clone-online-mac .extraclass class="requirement-machine"}
 Do a separate clone of the online repo on macOS, but don't do any autogen.sh, configure, or make, or open the Mobile Xcode project there yet. We call this the app folder.
 
-## 4) Clone Online on a Linux machine
+## 4) Clone Online
+### on a Linux machine ## {#ios-4-clone-online-linux .extraclass class="requirement-machine"}
 Do a separate clone of the online repo, run autogen.sh, and configure it with the --enable-iosapp option:
 
 ```bash

--- a/static/css/post-content.css
+++ b/static/css/post-content.css
@@ -1,0 +1,17 @@
+.extraclass.requirement-machine::before {
+  content: 'requires:';
+  background-color: salmon;
+  padding: 0 4px;
+  color: white;
+  border-radius: 4px;
+  margin-right: 4px;
+}
+
+.extraclass.requirement-machine {
+  text-transform: uppercase;
+  font-size: 1rem;
+  background-color: white;
+  border-radius: 3px;
+  padding: 4px;
+  color: salmon;
+}


### PR DESCRIPTION
Make it clear that it is the "basic edition" of POCO that we want.

The bit about the command line tools seems unnecessary, and at least
for me, there is no such /Library/Developer/CommandLineTools folder.

Signed-off-by: Tor Lillqvist <tml@collabora.com>