### PR TITLE
Add build instructions for Fedora and update Manjaro instructions

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -139,7 +139,7 @@ The instructions for Fedora will be here. [Submit an issue to contribute](https:
 
 ## Build CODE on Arch
 
-The instructions below have been prepared for and tested on Manjaro 21.2.0. You might need to do small adjustments for Arch and/or other Arch-based distributions.
+The instructions below have been prepared for and tested on Manjaro 21.2.3. You might need to do small adjustments for Arch and/or other Arch-based distributions.
 
 ### Dependencies
 We need LibreOffice core, POCO library and several other libraries and tools to build `CODE`.
@@ -151,7 +151,12 @@ sudo pacman -Syu libcap libcap-ng lib32-libcap libpng
 ```
 
 ```bash
-sudo pacman -Syu poco
+sudo pacman -Syu poco cppunit nodejs npm chromium
+```
+
+```bash
+sudo pacman -Syu python-pip
+sudo pip install polib lxlm
 ```
 
 ### LibreOffice

--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -132,7 +132,79 @@ Found a problem? [Submit an issue to contribute](https://github.com/CollaboraOnl
 <section id="build-code-fedora" class="build-code-content">
 
 ## Build CODE on Fedora
-The instructions for Fedora will be here. [Submit an issue to contribute](https://github.com/CollaboraOnline/online/issues/new)!
+
+The instructions below have been prepared for and tested on Fedora 35. You might need to do small adjustments for Fedora-based distributions.
+
+### Dependencies
+We need LibreOffice core, POCO library and several other libraries and tools to build `CODE`.
+
+Open a terminal and follow the steps below:
+
+```bash
+sudo dnf install poco-devel gcc gcc-c++ python3-polib \
+                 libtool libstdc++-devel libpng libpng-devel \
+                 cppunit-devel nodejs-devel
+```
+
+### LibreOffice
+CODE needs LibreOffice to be built to run. However, it takes a considerable amount of time and brings in extra complexity. So, we will instead download a daily built archive which contains only the pieces that are absolutely necessary. If you are working only on the online side, without doing any code-level changes on the LibreOffice core, or you just want to quickly get going to do some small fixes, then this will be enough for you. Otherwise, refer to the general instructions.
+
+Now download a daily-built archive of LibreOffice core:
+```bash
+wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-2021-assets.tar.gz
+```
+
+Extract the contents of the archive:
+```bash
+tar xvf core-co-2021-assets.tar.gz
+```
+
+Mark the location of the extracted contents before changing directory:
+```bash
+export LOCOREPATH=$(pwd)
+```
+
+### Building CODE
+You need to clone it, run autoconf/automake, configure and build using the GNU
+make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
+
+Now clone the forked repo:
+```bash
+git clone git@github.com:YOURUSERNAME/online.git collabora-online
+```
+
+Switch to the local clone's directory:
+```bash
+cd collabora-online
+```
+
+Run autogen to generate the configure file:
+```bash
+./autogen.sh
+```
+(install all missing packages that `./autogen.sh` couldn't find on your system)
+
+Run the generated configure script with proper parameters:
+```bash
+./configure --enable-silent-rules --with-lokit-path=${LOCOREPATH}/include \
+            --with-lo-path=${LOCOREPATH}/instdir \
+            --enable-debug --enable-cypress
+```
+Note: you can also add `--disable-ssl` instead of changing coolwsd.xml everytime you want to disable ssl.
+
+Start the actual build, which might take from a few minutes to half an hour (or more) depending on how powerful your machine is:
+```bash
+make -j $(nproc)
+```
+
+If you want to run the unit tests, use `make check` instead of the `make`.
+
+Note that the loolforkit program needs the `CAP_SYS_CHROOT` capability,
+thus **you will be asked the root password** when running make as it
+invokes `sudo` to run `/sbin/setcap`.
+
+Found a problem? [Submit an issue to contribute](https://github.com/CollaboraOnline/online/issues/new)!
+
 </section>
 
 <section id="build-code-arch" class="build-code-content">


### PR DESCRIPTION
Manjaro(Arch):
- installation guide added for `cppunit` `nodejs` `npm` `chromium` and some required python libraries.
- Manjaro version is updated.

Fedora:
- added new build instructions for Fedora 35.