### PR TITLE
Update GitHub new issue links to template chooser

### DIFF
--- a/content/post/filebugs.md
+++ b/content/post/filebugs.md
@@ -16,7 +16,7 @@ images = [
 +++
 
 Sorry about that — but you can help us resolving it by creating a great bug
-report! See the steps how to do it, and [file the bug on GitHub](https://github.com/CollaboraOnline/online/issues/new "File the bug on GitHub").
+report! See the steps how to do it, and [file the bug on GitHub](https://github.com/CollaboraOnline/online/issues/new/choose "File the bug on GitHub").
 
 <!--more-->
 ### How to file a good bug report
@@ -24,7 +24,7 @@ report! See the steps how to do it, and [file the bug on GitHub](https://github.
 When you find a bug, please make sure you can reproduce it and identify
 the necessary steps to trigger it. Then describe the steps on GitHub:
 
-    https://github.com/CollaboraOnline/online/issues/new
+    https://github.com/CollaboraOnline/online/issues/new/choose
 
 If the bug is specific to a file, please try to create a blank one and add just
 the content that causes the problem.


### PR DESCRIPTION
If one is following https://github.com/CollaboraOnline/online/issues/new which is currently linked at https://collaboraonline.github.io/post/filebugs/ just an empty issue input box is shown to the user without any choice of the available issue templates:

![box-before](https://user-images.githubusercontent.com/39667843/158253518-2c446737-e5d1-462b-8d3a-ceb0decab423.png)

Doing the same with the updated link gives now the expected template chooser:

![box-after](https://user-images.githubusercontent.com/39667843/158253675-e2e14c5a-2066-42be-94cd-c0e7cdc159a0.png)
