### PR TITLE
Make possible to send specific OS build link

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -55,6 +55,10 @@ _First published on [ Collabora Online Community Roundup #2](https://www.collabo
 
 </section>
 
+{{< running-code >}}
+
+---
+
 <section id="build-code-opensuse" class="build-code-content">
 
 ## Build CODE on openSUSE
@@ -128,6 +132,10 @@ invokes `sudo` to run `/sbin/setcap`.
 
 Found a problem? [Submit an issue to contribute](https://github.com/CollaboraOnline/online/issues/new)!
 </section>
+
+{{< running-code >}}
+
+---
 
 <section id="build-code-fedora" class="build-code-content">
 
@@ -206,6 +214,10 @@ invokes `sudo` to run `/sbin/setcap`.
 Found a problem? [Submit an issue to contribute](https://github.com/CollaboraOnline/online/issues/new)!
 
 </section>
+
+{{< running-code >}}
+
+---
 
 <section id="build-code-arch" class="build-code-content">
 
@@ -292,6 +304,10 @@ Found a problem? [Submit an issue to contribute](https://github.com/CollaboraOnl
 
 </section>
 
+{{< running-code >}}
+
+---
+
 <section id="build-code-ubuntu" class="build-code-content">
 
 ## Build CODE on Ubuntu
@@ -372,6 +388,10 @@ Note that the coolforkit program needs the `CAP_SYS_CHROOT` capability,
 thus **you will be asked the root password** when running make as it
 invokes `sudo` to run `/sbin/setcap`.
 </section>
+
+{{< running-code >}}
+
+---
 
 <section id="build-code-general" class="build-code-content">
 
@@ -465,26 +485,6 @@ thus you will be asked the root password when running make as it
 invokes sudo to run `/sbin/setcap`.
 </section>
 
-### Running
-
-Now do:
-
-    make run
-
-Among other, the output will contain the links that you can directly follow to
-see Writer, Calc, and Impress test documents in your browser.
-
-### Hacking it
-
-When you change a JavaScript file (they are located under the browser/
-subdirectory), you need to stop the existing CODE instance and issue `make
-run` again, because the files are cached.
-
-Alternatively you can export a variable like:
-
-    export COOL_SERVE_FROM_FS=1
-
-to avoid the caching, so that you can just Shift+Reload the pages to see the
-new content.
+{{< running-code >}}
 
 {{< edit-button to="/content/post/build-code.md" name="Edit page">}}

--- a/layouts/shortcodes/build-dropdown.html
+++ b/layouts/shortcodes/build-dropdown.html
@@ -3,21 +3,20 @@
     Choose Operating System
   </button>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-    <span class="dropdown-item" href="#" onclick="opensuse"><em class="gnu-linux">GNU/Linux</em> openSUSE</span>
-    <span class="dropdown-item" href="#" onclick="ubuntu"><em class="gnu-linux">GNU/Linux</em> Ubuntu</span>
-    <span class="dropdown-item" href="#" onclick="fedora"><em class="gnu-linux">GNU/Linux</em> Fedora</span>
-    <span class="dropdown-item" href="#" onclick="arch"><em class="gnu-linux">GNU/Linux</em> Arch (Manjaro etc.)</span>
-    <span class="dropdown-item" href="#" onclick="general"><em class="gnu-linux">GNU/Linux</em> General Instructions</span>
-    <span class="dropdown-item" href="#" onclick="gitpod">Gitpod (Windows, Mac, Linux, etc)</span>
+    <a href="#build-code-on-opensuse"><span class="dropdown-item" onclick="opensuse"><em class="gnu-linux">GNU/Linux</em> openSUSE</span></a>
+    <a href="#build-code-on-ubuntu"><span class="dropdown-item" onclick="ubuntu"><em class="gnu-linux">GNU/Linux</em> Ubuntu</span></a>
+    <a href="#build-code-on-fedora"><span class="dropdown-item" onclick="fedora"><em class="gnu-linux">GNU/Linux</em> Fedora</span></a>
+    <a href="#build-code-on-arch"><span class="dropdown-item" onclick="arch"><em class="gnu-linux">GNU/Linux</em> Arch (Manjaro etc.)</span></a>
+    <a href="#build-code"><span class="dropdown-item" onclick="general"><em class="gnu-linux">GNU/Linux</em> General Instructions</span></a>
+    <a href="#build-code-on-gitpod"><span class="dropdown-item" href="#" onclick="gitpod">Gitpod (Windows, Mac, Linux, etc)</span></a>
   </div>
 </div>
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script type="text/javascript">
-	$( ".dropdown-item" ).click(function() {
-		$( ".build-code-content").hide();
-		$( "#build-code-" + $(this).attr('onclick')).show();
-	});
-	$("#TableOfContents a[href^='#build-']").click(function(){
-		$( ".build-code-content").show();
-	});
+
+  $(document).ready(function () {
+    $(".build-code-content").show();
+    $(".dropdown-menu > a[href^='#build-code']").css("text-decoration", "none");
+  });
+
 </script>

--- a/layouts/shortcodes/running-code.html
+++ b/layouts/shortcodes/running-code.html
@@ -1,0 +1,12 @@
+<h3>Running</h3>
+<p>Now do:</p>
+<pre><code>make run</code></pre>
+<p>Among other, the output will contain the links that you can directly follow to
+see Writer, Calc, and Impress test documents in your browser.</p>
+<h3>Hacking it</h3>
+<p>When you change a JavaScript file (they are located under the browser/
+subdirectory), you need to stop the existing CODE instance and issue <code>make run</code> again, because the files are cached.</p>
+<p>Alternatively you can export a variable like:</p>
+<pre><code>export COOL_SERVE_FROM_FS=1</code></pre>
+<p>to avoid the caching, so that you can just Shift+Reload the pages to see the
+new content.</p>


### PR DESCRIPTION
Resolves: Modify Choose Operating System dropdown menu in build-code page #34 

- updated dropdown menu in build-dropdown.html
- all element in build-code.md is made visible
- created {{< running-code >}} shortcut to
avoid duplicates in build-code.md
