### PR TITLE
Fix a command in the code-needs-lo-wget template

### DIFF
--- a/layouts/shortcodes/common-build-commands.md
+++ b/layouts/shortcodes/common-build-commands.md
@@ -19,7 +19,7 @@ Export the location of the extracted contents as a variable before changing dire
 export LOCOREPATH=$(pwd)
 
 # Or make it persistent as part of your .bashrc with
-echo "export LOCOREPATH=$(pwd)" >> .bashrc && source .bashrc 
+echo "export LOCOREPATH=$(pwd)" >> ~/.bashrc && source ~/.bashrc
 ```
 {{ end }}
 


### PR DESCRIPTION
- The code-needs-lo-wget template contains a line to persistently store
  the location of an extracted libreoffice assets download
- The template previously referred to '.bashrc', however this isn't the
  correct location if the user is anywhere but their home directory.
  Instead, '~/.bashrc' will work no matter where the user is

Signed-off-by: Skyler Grey <skyler3665@gmail.com>