### PR TITLE
Rename the Ubuntu build steps to Ubuntu/Debian

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -188,10 +188,10 @@ Now clone the forked repo:
 
 ---
 
-<section id="build-code-ubuntu" class="build-code-content">
+<section id="build-code-debian-ubuntu" class="build-code-content">
 
-## Ubuntu {#build-code-on-ubuntu}
-The instructions below have been prepared for and tested on Ubuntu 20.04 LTS. You might need to do small
+## Debian/Ubuntu {#build-code-on-debian-ubuntu}
+The instructions below have been prepared for and tested on Ubuntu 20.04 LTS, and tested on Debian GNU/Linux 11 (bullseye). You might need to do small
 adjustments for other releases.
 
 ### Dependencies

--- a/layouts/shortcodes/build-dropdown.html
+++ b/layouts/shortcodes/build-dropdown.html
@@ -4,7 +4,7 @@
   </button>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
     <a href="#build-code-on-opensuse"><span class="dropdown-item"><em class="gnu-linux">GNU/Linux</em> openSUSE</span></a>
-    <a href="#build-code-on-ubuntu"><span class="dropdown-item"><em class="gnu-linux">GNU/Linux</em> Ubuntu</span></a>
+    <a href="#build-code-on-debian-ubuntu"><span class="dropdown-item"><em class="gnu-linux">GNU/Linux</em> Debian (Ubuntu etc.)</span></a>
     <a href="#build-code-on-fedora"><span class="dropdown-item"><em class="gnu-linux">GNU/Linux</em> Fedora</span></a>
     <a href="#build-code-on-arch"><span class="dropdown-item"><em class="gnu-linux">GNU/Linux</em> Arch (Manjaro etc.)</span></a>
     <a href="#build-code-n-lo"><span class="dropdown-item"><em class="gnu-linux">GNU/Linux</em> General Instructions</span></a>


### PR DESCRIPTION
- The build steps work in my debian 11 Docker container
- As we don't have other build steps for Debian, it's nice to mention it
  as well as Ubuntu since as Debian/Debian-based distros are fairly
  common outside of Ubuntu
- This change also brings the instructions up to parity with the Arch
  section, which was created for Manjaro but is titled Arch

Signed-off-by: Skyler Grey <skyler3665@gmail.com>