### PR TITLE
Fix a double colon in the build steps

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -246,7 +246,7 @@ The CODE must be built on Linux, and you need the following:
 * libpng, libcap-progs, libtool, automake, autoconf, pkg-config, sudo, pam
   + use the packages from your distro
 
-You may also want to have the following optional dependencies::
+You may also want to have the following optional dependencies:
 
 * Chromium
   + Needed for running cypress tests


### PR DESCRIPTION
- This was introduced in #44
- This commit fixes #47

Signed-off-by: Skyler Grey <skyler3665@gmail.com>