### PR TITLE
Add a note under Debian saying that sudo is needed

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -194,6 +194,8 @@ Now clone the forked repo:
 The instructions below have been prepared for and tested on Ubuntu 20.04 LTS, and tested on Debian GNU/Linux 11 (bullseye). You might need to do small
 adjustments for other releases.
 
+*Note: Sometimes Debian comes without sudo preinstalled. If you do not have sudo, you will need to run `apt install -y sudo` as root. It is not good enough to only run the commands which require sudo below as root, as sudo is also run during `make`*
+
 ### Dependencies
 We need LibreOffice core, POCO library and several other libraries and tools to build `CODE`. Open a terminal and follow the steps below.
 


### PR DESCRIPTION
- Sometimes (i.e. in Docker containers) Debian doesn't have sudo
  installed by default
- If there isn't sudo on a system, our build instructions won't work.
  This PR tells the reader about this for the Debian instructions

Signed-off-by: Skyler Grey <skyler3665@gmail.com>