### PR TITLE
Update the arch build instructions

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -154,18 +154,14 @@ The instructions below have been prepared for and tested on Manjaro 21.2.3. You 
 We need LibreOffice core, POCO library and several other libraries and tools to build `CODE`.
 
 Open a terminal and follow the steps below:
-
 ```bash
-sudo pacman -Syu libcap libcap-ng lib32-libcap libpng
+sudo pacman -Syu libcap libcap-ng lib32-libcap libpng poco cppunit nodejs npm chromium python-lxml
 ```
 
-```bash
-sudo pacman -Syu poco cppunit nodejs npm chromium
-```
-
+Additionally you will need to install python-polib. You can do this using pip (as below) *or* using [the python-polib AUR package](https://aur.archlinux.org/packages/python-polib)
 ```bash
 sudo pacman -Syu python-pip
-sudo pip install polib lxlm
+sudo pip install polib
 ```
 
 ### LibreOffice


### PR DESCRIPTION
- Fix a typo in lxml
- Move lxml to use the python-lxml arch package
- Mention the AUR package as an alternative method of installing polib
- Merge all pacman installations onto a single line
- These changes were triggered by messages from `Rash` in irc which
  noted the typo and asked for the AUR package to be used

Signed-off-by: Skyler Grey <skyler3665@gmail.com>