### PR TITLE
Update the build instructions to mention the latest LibreOffice version

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -319,17 +319,17 @@ To build LibreOffice, follow the LibreOffice building pages:
 
 https://wiki.documentfoundation.org/Development/BuildingOnLinux
 
-Make sure you use and build the following specific core branch: `distro/collabora/co-22.05`
+Make sure you use and build the following specific core branch: `distro/collabora/co-23.05`
 
 #### Option B - Download a Daily-Built Archive of LibreOffice (Quick & Dirty)
 Download the daily archive:
 ```
-wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-22.05-assets.tar.gz
+wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-23.05-assets.tar.gz
 ```
 
 Extract the archive:
 ```
-tar xvf core-co-22.05-assets.tar.gz
+tar xvf core-co-23.05-assets.tar.gz
 ```
 
 You should now have two new directories extracted: `instdir` and `include`. You will use the locations of these directories for the `configure` parameters in the following steps.

--- a/layouts/shortcodes/common-build-commands.md
+++ b/layouts/shortcodes/common-build-commands.md
@@ -6,12 +6,12 @@ extra complexity. So, we will instead download a daily built archive which conta
 
 Now download a daily-built archive of LibreOffice core:
 ```bash
-wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-22.05-assets.tar.gz
+wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-23.05-assets.tar.gz
 ```
 
 Extract the contents of the archive:
 ```bash
-tar xvf core-co-22.05-assets.tar.gz
+tar xvf core-co-23.05-assets.tar.gz
 ```
 
 Export the location of the extracted contents as a variable before changing directory:


### PR DESCRIPTION
If you use co-22.05 rather than 23.05 but still build the latest collabora, your build will fail partway through with some challenging-to-debug errors. By supplying the correct version in our docs we can avoid people being put off by errors from old versions of LO