### PR TITLE
Add a link to the general instructions

### DIFF
--- a/layouts/shortcodes/common-build-commands.md
+++ b/layouts/shortcodes/common-build-commands.md
@@ -2,7 +2,7 @@
 
 {{ if eq $section "code-needs-lo-wget" }}
 CODE needs LibreOffice to be built to run. However, it takes a considerable amount of time and brings in
-extra complexity. So, we will instead download a daily built archive which contains only the pieces that are absolutely necessary. If you are working only on the online side, without doing any code-level changes on the LibreOffice core, or you just want to quickly get going to do some small fixes, then this will be enough for you. Otherwise, refer to the general instructions.
+extra complexity. So, we will instead download a daily built archive which contains only the pieces that are absolutely necessary. If you are working only on the online side, without doing any code-level changes on the LibreOffice core, or you just want to quickly get going to do some small fixes, then this will be enough for you. Otherwise, [refer to the general instructions](/post/build-code/#build-code-n-lo).
 
 Now download a daily-built archive of LibreOffice core:
 ```bash


### PR DESCRIPTION
- We commonly say in the building documentation to refer to the general instructions
- It's quite nice for developers to be able to click-through directly rather than figuring out that we mean the "Build CODE & LO" section and navigating to it manually