### PR TITLE
build: Fedora need python3-lxml

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -135,7 +135,7 @@ We need LibreOffice core, POCO library and several other libraries and tools to 
 Open a terminal and follow the steps below:
 
 ```bash
-sudo dnf install poco-devel gcc gcc-c++ python3-polib \
+sudo dnf install poco-devel gcc gcc-c++ python3-polib python3-lxml \
                  libtool libstdc++-devel libpng libpng-devel \
                  cppunit-devel nodejs-devel chromium \
                  libzstd-devel libcap-devel pam-devel


### PR DESCRIPTION
`python3-lxml` was missing on my default f38 podman/toolbox image, after installing the other dependencies.