### PR TITLE
Update iOS build instructions

### DIFF
--- a/content/post/build-code-ios.md
+++ b/content/post/build-code-ios.md
@@ -22,6 +22,26 @@ Are you familiar with iOS development environment and interested to learn more w
 <!--more-->
 # How to build the iOS app:
 
+## You will need
+
+### A developer program enrollment ## {#ios-1-build-Lo-mac .extraclass class="requirement-machine"}
+
+You will need an Apple ID that is a member of the Apple Developer program, as Collabora iOS relies on Fonts and iCloud capabilities, which are only available to accounts in the developer platform
+
+If you don't have an account in the developer program, you can enroll [on Apple's developer program website](https://developer.apple.com/programs/enroll/). It costs $99 USD per year to enroll. If you are developing Collabora iOS for work your employer may be able to [add you to a development team](https://developer.apple.com/help/account/manage-your-team/invite-team-members/)
+
+### A Mac ## {#ios-1-build-Lo-mac .extraclass class="requirement-machine"}
+You will need a Mac with [Xcode](https://apps.apple.com/gb/app/xcode/id497799835) installed
+
+Intel Macs should work, although this guide has only been tested with a Mac Mini 2023, which has an Apple M2 chip
+
+### An iOS or iPadOS device ## {#ios-1-build-Lo-mac .extraclass class="requirement-machine"}
+
+**Collabora Office cannot run in a simulator** because the LibreOfficeKit bits are built for an `iOS` target, but the simulator is `iOS-simulator`. Therefore, you'll need a real device to run this.
+
+Building for `My Mac (Designed for iPad)` on Mac Silicon will run, but it is unstable. In particular, sometimes bugs are present on Mac that are not present on a mobile device or vice-versa. We strongly suggest you build and run for a physical iOS or iPadOS device.
+
+
 ## 1) Build the LibreOfficeKit code for iOS
 ### on a Mac ## {#ios-1-build-Lo-mac .extraclass class="requirement-machine"}
 

--- a/content/post/build-code-ios.md
+++ b/content/post/build-code-ios.md
@@ -28,12 +28,10 @@ Are you familiar with iOS development environment and interested to learn more w
 
 You will need an Apple ID that is a member of the Apple Developer program, as Collabora iOS relies on Fonts and iCloud capabilities, which are only available to accounts in the developer platform
 
-If you don't have an account in the developer program, you can enroll [on Apple's developer program website](https://developer.apple.com/programs/enroll/). It costs $99 USD per year to enroll. If you are developing Collabora iOS for work your employer may be able to [add you to a development team](https://developer.apple.com/help/account/manage-your-team/invite-team-members/)
+If you don't have an account in the developer program, you can enroll [on Apple's developer program website](https://developer.apple.com/programs/enroll/). If you are developing Collabora iOS for work your employer may be able to [add you to a development team](https://developer.apple.com/help/account/manage-your-team/invite-team-members/)
 
 ### A Mac ## {#ios-1-build-Lo-mac .extraclass class="requirement-machine"}
 You will need a Mac with [Xcode](https://apps.apple.com/gb/app/xcode/id497799835) installed
-
-Intel Macs should work, although this guide has only been tested with a Mac Mini 2023, which has an Apple M2 chip
 
 ### An iOS or iPadOS device ## {#ios-1-build-Lo-mac .extraclass class="requirement-machine"}
 


### PR DESCRIPTION
the iOS build instructions are currently a little bit of a mess. They're outdated in places, riddled with potential footguns (e.g. the zstd "helper script" seems to call its include directory 'lib', and the page doesn't tell you about this), and tell you requirements (including the need for a 100-dollar-per-year apple developer account!) as you go through, so if you're just linearly following the guide there's a good chance you'll run into disappointment.

This PR aims to fix all of those issues, because we love good docs.

- [x] List prerequisites at the top of the page
- [ ] Detail LODE instructions
- [ ] Update zstd & poco instructions, and add detail
- [ ] Improve xcode screenshots
  - [ ] Add screenshots of what to click in xcode
  - [ ] embed screenshots rather than linking out
- [ ] Test new documentation
- [ ] Clean up committer & sign commits