### PR TITLE
Clarify build instructions

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -332,22 +332,30 @@ You may also want to have the following optional dependencies:
 
 ### LibreOffice
 
-CODE needs LibreOffice to be built to run. However, you have two options to meet this requirement: either by building it locally (Option A - recommended), or by downloading a daily built archive (Option B - quick & dirty) which contains only the absolutely necessary pieces. If you are working only on the online side, without doing any code-level changes on the LibreOffice core, or you just want to quickly get going to do some small fixes, you may prefer the second way.
+CODE needs LibreOffice to be built to run. You have two options to meet this requirement: either by building it locally (Option A - recommended), or by downloading a daily built archive (Option B - quick & dirty) which contains only the absolutely necessary pieces. If you are working only on the online side, without doing any code-level changes on the LibreOffice core, or you just want to quickly get going to do some small fixes, you may prefer the second way.
 
 #### Option A - Build LibreOffice locally (Recommended)
-To build LibreOffice, follow the LibreOffice building pages:
+The build process for LibreOffice is described on their wiki. However, a few modifications are needed in order to support building CODE.
 
 https://wiki.documentfoundation.org/Development/BuildingOnLinux
 
-Make sure you use and build the following specific core branch:
-```
+Install the dependencies. The lists of dependencies and commands for various distributions of Linux are avialable on the LibreOffice Wiki linked above.
+
+Clone the repository and switch to the Collabora Online branch:
+```bash
+git clone https://gerrit.libreoffice.org/core libreoffice
+cd libreoffice
 git checkout distro/collabora/co-23.05
 ```
 
-Also add the following configuration options to `autogen.sh` or `autogen.input`:
-```
+Configure and build, adding the following configuration options to `autogen.sh` or `autogen.input`:
+```bash
 ./autogen.sh --with-distro=CPLinux-LOKit --without-package-format
 ```
+```bash
+make -j $(nproc)
+```
+You can expect this process to take at least an hour or two the first time, possibly more depending on your machine and your internet connection. Subsequent builds will be faster.
 
 #### Option B - Download a Daily-Built Archive of LibreOffice (Quick & Dirty)
 Download the daily archive:

--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -339,18 +339,24 @@ To build LibreOffice, follow the LibreOffice building pages:
 
 https://wiki.documentfoundation.org/Development/BuildingOnLinux
 
-Make sure you use and build the following specific core branch: `distro/collabora/co-23.05` and build with the following config:
+Make sure you use and build the following specific core branch:
+```
+git checkout distro/collabora/co-23.05
+```
 
-    ./autogen.sh --with-distro=CPLinux-LOKit --without-package-format --without-system-nss
+Also add the following configuration options to `autogen.sh` or `autogen.input`:
+```
+./autogen.sh --with-distro=CPLinux-LOKit --without-package-format
+```
 
 #### Option B - Download a Daily-Built Archive of LibreOffice (Quick & Dirty)
 Download the daily archive:
-```
+```bash
 wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-23.05-assets.tar.gz
 ```
 
 Extract the archive:
-```
+```bash
 tar xvf core-co-23.05-assets.tar.gz
 ```
 
@@ -363,26 +369,27 @@ make:
 {{% common-build-commands section="clone-online" %}}
 ```bash
 ./autogen.sh
-```
-```bash
 ./configure --with-lokit-path=<LIBREOFFICEDIRECTORY>/include \
             --with-lo-path=<LIBREOFFICEDIRECTORY>/instdir \
+            --enable-debug \
+            --disable-ssl
 ```
 
 where `<LIBREOFFICEDIRECTORY>` is the location of the LibreOffice source tree you have built
-in the previous steps. `
+in the previous steps.
 
-You can also add extra flags to customize your build
+You can also add extra flags to customize your build:
 
 - If you built POCO from source, add `--with-poco-includes=<POCODIRECTORY>/include --with-poco-libs=<POCODIRECTORY>/lib`
-- Add `--enable-debug` to enable debugging and link with debugging versons of POCO libraries
 - Add `--enable-silent-rules` to create less verbose build output
-- Add `--disable-ssl` instead of changing coolwsd.xml everytime you want to disable ssl.
-- If you installed chromium as an optional dependency you can add `--enable-cypress` to enable tests which use a browser
+- Add `--enable-cypress` to enable tests which use a browser (requires Chromium)
+
+See `./configure --help` for the full list of options.
 
 ```bash
 make -j `nproc`
 ```
+
 {{% common-build-commands section="run-unit-test" %}}
 
 {{% common-build-commands section="running" %}}

--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -312,11 +312,11 @@ Now clone the forked repo:
 The CODE must be built on Linux, and you need the following:
 
 * LibreOffice
-  + you need to build your own tree
+  + Either build LibreOffice from source, or download a daily built archive (see below)
 * Poco library: http://pocoproject.org/
-  + either use a package from your distro, or build it yourself (see below)
+  + Either use the package from your distro, or build it yourself, ideally 1.10.1 or later
 * libpng, libcap-progs, libtool, automake, autoconf, pkg-config, sudo, pam
-  + use the packages from your distro
+  + Use the packages from your distro
 
 You may also want to have the following optional dependencies:
 
@@ -339,7 +339,9 @@ To build LibreOffice, follow the LibreOffice building pages:
 
 https://wiki.documentfoundation.org/Development/BuildingOnLinux
 
-Make sure you use and build the following specific core branch: `distro/collabora/co-23.05` and build with the following config: `./autogen.sh --with-distro=CPLinux-LOKit`
+Make sure you use and build the following specific core branch: `distro/collabora/co-23.05` and build with the following config:
+
+    ./autogen.sh --with-distro=CPLinux-LOKit --without-package-format --without-system-nss
 
 #### Option B - Download a Daily-Built Archive of LibreOffice (Quick & Dirty)
 Download the daily archive:
@@ -354,24 +356,6 @@ tar xvf core-co-23.05-assets.tar.gz
 
 You should now have two new directories extracted: `instdir` and `include`. You will use the locations of these directories for the `configure` parameters in the following steps.
 
-### POCO
-
-If you use openSUSE Leap 15.3, you can use:
-
-    zypper ar http://download.opensuse.org/repositories/devel:/libraries:/c_c++/openSUSE_Leap_15.3/devel:libraries:c_c++.repo
-    zypper in poco-devel libcap-progs python3-polib libcap-devel npm libtool cppunit-devel pam-devel python3-lxml
-
-Similar repos exist for other openSUSE and SLE releases.
-
-Collabora provides Poco packages for Debian 8, Debian 9, Ubuntu 16.04 LTS,
-and CentOS 7 via the CODE (Collabora Online Development Edition) repositories,
-see:
-
-https://www.collaboraoffice.com/code/linux-packages/
-
-Alternatively you can build your own POCO. In that case, ideally use a recent version like
-1.10.1 or newer.
-
 ### Building CODE
 
 You need to clone it, run autoconf/automake, configure and build using the GNU
@@ -381,25 +365,24 @@ make:
 ./autogen.sh
 ```
 ```bash
-./configure --enable-silent-rules --with-lokit-path=${MASTER}/include \
-            --with-lo-path=${MASTER}/instdir \
-            --with-poco-includes=<POCOINST>/include --with-poco-libs=<POCOINST>/lib \
-            --enable-debug
+./configure --with-lokit-path=<LIBREOFFICEDIRECTORY>/include \
+            --with-lo-path=<LIBREOFFICEDIRECTORY>/instdir \
 ```
+
+where `<LIBREOFFICEDIRECTORY>` is the location of the LibreOffice source tree you have built
+in the previous steps. `
 
 You can also add extra flags to customize your build
 
-- You can also add `--disable-ssl` instead of changing coolwsd.xml everytime you want to disable ssl.
+- If you built POCO from source, add `--with-poco-includes=<POCODIRECTORY>/include --with-poco-libs=<POCODIRECTORY>/lib`
+- Add `--enable-debug` to enable debugging and link with debugging versons of POCO libraries
+- Add `--enable-silent-rules` to create less verbose build output
+- Add `--disable-ssl` instead of changing coolwsd.xml everytime you want to disable ssl.
 - If you installed chromium as an optional dependency you can add `--enable-cypress` to enable tests which use a browser
 
 ```bash
 make -j `nproc`
 ```
-In the above, `${MASTER}` is the location of the LibreOffice source tree you have built
-in the previous steps. `POCOINST` is the location of your custom-built or externally installed POCO library.
-If you use POCO from a distro package (not a self-built version), you can omit
-the `--with-poco-includes` and `--with-poco-libs` from the above.
-
 {{% common-build-commands section="run-unit-test" %}}
 
 {{% common-build-commands section="running" %}}

--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -95,11 +95,8 @@ The instructions below have been prepared for and tested on openSUSE Leap 15.3. 
 We need LibreOffice core, POCO library and several other libraries and tools to build `CODE`. Open a terminal and follow the steps below.
 
 ```bash
-# For Leap 15.3
-zypper ar http://download.opensuse.org/repositories/devel:/libraries:/c_c++/15.3/devel:libraries:c_c++.repo
-
-# For Leap 15.4
-zypper ar http://download.opensuse.org/repositories/devel:/libraries:/c_c++/15.4/devel:libraries:c_c++.repo
+# For Leap 15.5
+zypper ar http://download.opensuse.org/repositories/devel:/libraries:/c_c++/15.5/devel:libraries:c_c++.repo
 ```
 If this is fresh instalation it might be worth install devel-basis pattern: Minimal set of tools for compiling and linking applications.
 It will bring in things like git, gcc, etc.


### PR DESCRIPTION
When I was learning to build CODE, I got stuck for a while on POCO, even trying (unsuccessfully) to build it myself. This was unnecessary because I had already downloaded libpoco-dev from the steps above. I think most people will use the packages from their distribution, so I deleted the whole section to make it less confusing. Also, the Collabora repos don't seem to contain the packages, and the distributions mentioned are no longer current.

I also got stuck for a long time on separate issues that were resolved by using --without-package-format and --without-system-nss when building LibreOffice. I don't know exactly what they do or if they apply to everyone, but if it makes the build more likely to work on the first try I think they should be included here.

I was not able to build or test these changes. I was writing bare markdown. So they will need to be viewed or tested first.

I also did not re-test the build instructions. The changes are based only on notes I made while building for the first time on Debian. If they need to be re-run from scratch I'd be happy to do that.