### PR TITLE
Update chat urls

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -59,7 +59,7 @@ type = "type"
   [params.social]
     rss = true
     email = "hello@collaboraoffice.com"
-    chat = "https://matrix.to/#/#cool-dev:libera.chat"
+    chat = "https://matrix.to/#/#cool-dev:clicks.codes"
     facebook = "https://www.facebook.com/collaboraoffice/"
     twitter = "https://twitter.com/CollaboraOffice"
     linkedin = "https://www.linkedin.com/company/collabora-productivity-ltd/"

--- a/content/docs.md
+++ b/content/docs.md
@@ -41,9 +41,7 @@ For more detailed and pretty instructions on integrating with various partner so
 * Read the full guide on [Contributing](https://github.com/CollaboraOnline/online/blob/master/CONTRIBUTING.md)
 * Read the [Code of Conduct](https://github.com/CollaboraOnline/online/blob/master/CODE_OF_CONDUCT.md)
 * To ask questions, use the [Collabora Online forum](https://forum.collaboraonline.com)
-* To talk to other developers, please join the IRC [Libera.​Chat/#cool-dev channel](irc://irc.libera.chat/#cool-dev)
-  + you can get there directly via a [Webchat](https://web.libera.chat/#cool-dev)
-  + you can also join via [Matrix](https://matrix.to/#/#cool-dev:libera.chat)
++ To talk with other developers please join us on [Matrix](https://matrix.to/#/#cool-dev:clicks.codes)
 * And feel free to share your contributions and iterations on twitter by tagging [@CollaboraOffice](https://twitter.com/CollaboraOffice) or [@CollaboraOffice@mastodon.social](https://mastodon.social/@CollaboraOffice) and using the `#cool_dev`
 
 ### Your first commit

--- a/content/post/communicate.md
+++ b/content/post/communicate.md
@@ -31,9 +31,7 @@ A great way to get in touch, ask anything or get mentoring is through one of our
 
 ## Get in touch
 * Chat on [Collabora Online forum](https://forum.collaboraonline.com/)
-* ~~Chat via [Libera.Chat/#cool-dev channel](irc://irc.libera.chat/#cool-dev) (you can get there directly via a [Webchat](https://web.libera.chat/#cool-dev))~~
-  * For now the libera.chat bridge is down. Please use Matrix or Telegram instead.
-* Chat via [Matrix](https://app.element.io/#/room/#cool-dev:libera.chat)
+* Chat via [Matrix](https://app.element.io/#/room/#cool-dev:clicks.codes)
 * Chat on [Telegram:CollaboraOnline](https://t.me/CollaboraOnline)
 * Send email [hello@collaboraoffice.com](mailto:hello@collaboraoffice.com)
 * Twitter [@CollaboraOffice](https://twitter.com/CollaboraOffice) feel free to use `#cool_dev` in your tweets


### PR DESCRIPTION
- libera.chat shut down their matrix bridge, so we switched fully to Matrix. Therefore, we shouldn't have reference to using the IRC
- when the matrix bridge went down, the homeserver also stopped being able to resolve room addresses, this meant that cool-dev:libera.chat would work in some cases (e.g. if you were already in it) but would break if you were not.

  For CollaboraOnline/online/f522c2f828458dcbdc10b981c64d45916d674616 I made a local address on my own homeserver (#cool-dev:clicks.codes), this works so let's update the URLs here to match that too