### PR TITLE
Build code: Fix version. Move numbers outside of shortcode

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -112,14 +112,14 @@ zypper in libpng16-compat-devel
 ```
 
 ### LibreOffice
-{{% common-build-commands section="code-needs-lo-wget" %}}
+{{% common-build-commands section="code-needs-lo-wget" lotar="core-co-24.04-assets.tar.gz" %}}
 
 ### Building CODE
 You need to clone it, run autoconf/automake, configure and build using the GNU
 make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
 
 Now clone the forked repo:
-{{% common-build-commands section="clone-online" %}}
+{{% common-build-commands section="clone-online" lobranch="co-24.04" %}}
 
 {{% common-build-commands section="build-online" %}}
 
@@ -150,14 +150,14 @@ sudo dnf install poco-devel gcc gcc-c++ python3-polib python3-lxml \
 ```
 
 ### LibreOffice
-{{% common-build-commands section="code-needs-lo-wget" %}}
+{{% common-build-commands section="code-needs-lo-wget" lotar="core-co-24.04-assets.tar.gz" %}}
 
 ### Building CODE
 You need to clone it, run autoconf/automake, configure and build using the GNU
 make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
 
 Now clone the forked repo:
-{{% common-build-commands section="clone-online" %}}
+{{% common-build-commands section="clone-online" lobranch="co-24.04" %}}
 
 {{% common-build-commands section="build-online" %}}
 
@@ -190,14 +190,14 @@ sudo pip install polib
 ```
 
 ### LibreOffice
-{{% common-build-commands section="code-needs-lo-wget" %}}
+{{% common-build-commands section="code-needs-lo-wget" lotar="core-co-24.04-assets.tar.gz" %}}
 
 ### Building CODE
 You need to clone it, run autoconf/automake, configure and build using the GNU
 make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
 
 Now clone the forked repo:
-{{% common-build-commands section="clone-online" %}}
+{{% common-build-commands section="clone-online" lobranch="co-24.04" %}}
 
 {{% common-build-commands section="build-online" %}}
 
@@ -236,14 +236,14 @@ sudo apt install -y libpoco-dev python3-polib libcap-dev npm \
 ```
 
 ### LibreOffice
-{{% common-build-commands section="code-needs-lo-wget" %}}
+{{% common-build-commands section="code-needs-lo-wget" lotar="core-co-24.04-assets.tar.gz" %}}
 
 ### Building CODE
 You need to clone it, run autoconf/automake, configure and build using the GNU
 make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
 
 Now clone the forked repo:
-{{% common-build-commands section="clone-online" %}}
+{{% common-build-commands section="clone-online" lobranch="co-24.04" %}}
 
 {{% common-build-commands section="build-online" %}}
 
@@ -281,14 +281,14 @@ sudo apt install -y libpoco-dev python3-polib libcap-dev npm \
 *Note: Chomium is needed and used in cypress tests. Ubuntu has no chromium deb packages in its repositories, only a dummy pacakge that points to the respective snap. Probably best to make sure you have snapd installed and install chromium-browser which in turn will install the snap package.*
 
 ### LibreOffice
-{{% common-build-commands section="code-needs-lo-wget" %}}
+{{% common-build-commands section="code-needs-lo-wget" lotar="core-co-24.04-assets.tar.gz" %}}
 
 ### Building CODE
 You need to clone it, run autoconf/automake, configure and build using the GNU
 make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
 
 Now clone the forked repo:
-{{% common-build-commands section="clone-online" %}}
+{{% common-build-commands section="clone-online" lobranch="co-24.04" %}}
 
 {{% common-build-commands section="build-online" %}}
 
@@ -339,11 +339,7 @@ https://wiki.documentfoundation.org/Development/BuildingOnLinux
 Install the dependencies. The lists of dependencies and commands for various distributions of Linux are avialable on the LibreOffice Wiki linked above.
 
 Clone the repository and switch to the Collabora Online branch:
-```bash
-git clone https://gerrit.libreoffice.org/core libreoffice
-cd libreoffice
-git checkout distro/collabora/co-24.04
-```
+{{% common-build-commands section="clone-lo" lobranch="co-24.04" %}}
 
 Configure and build, adding the following configuration options to `autogen.sh` or `autogen.input`:
 ```bash
@@ -355,15 +351,7 @@ make -j $(nproc)
 You can expect this process to take at least an hour or two the first time, possibly more depending on your machine and your internet connection. Subsequent builds will be faster.
 
 #### Option B - Download a Daily-Built Archive of LibreOffice (Quick & Dirty)
-Download the daily archive:
-```bash
-wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-24.04-assets.tar.gz
-```
-
-Extract the archive:
-```bash
-tar xvf core-co-24.04-assets.tar.gz
-```
+{{% common-build-commands section="code-needs-lo-wget" lotar="core-co-24.04-assets.tar.gz" %}}
 
 You should now have two new directories extracted: `instdir` and `include`. You will use the locations of these directories for the `configure` parameters in the following steps.
 
@@ -371,17 +359,8 @@ You should now have two new directories extracted: `instdir` and `include`. You 
 
 You need to clone it, run autoconf/automake, configure and build using the GNU
 make:
-{{% common-build-commands section="clone-online" %}}
-```bash
-./autogen.sh
-./configure --with-lokit-path=<LIBREOFFICEDIRECTORY>/include \
-            --with-lo-path=<LIBREOFFICEDIRECTORY>/instdir \
-            --enable-debug \
-            --disable-ssl
-```
-
-where `<LIBREOFFICEDIRECTORY>` is the location of the LibreOffice source tree you have built
-in the previous steps.
+{{% common-build-commands section="clone-online" lobranch="co-24.04" %}}
+{{% common-build-commands section="build-online" %}}
 
 You can also add extra flags to customize your build:
 

--- a/layouts/shortcodes/common-build-commands.md
+++ b/layouts/shortcodes/common-build-commands.md
@@ -6,12 +6,12 @@ extra complexity. So, we will instead download a daily built archive which conta
 
 Now download a daily-built archive of LibreOffice core:
 ```bash
-wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-23.05-assets.tar.gz
+wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/{{.Get "lotar"}}
 ```
 
 Extract the contents of the archive:
 ```bash
-tar xvf core-co-23.05-assets.tar.gz
+tar xvf {{.Get "lotar"}}
 ```
 
 Export the location of the extracted contents as a variable before changing directory:
@@ -41,6 +41,15 @@ export COOL_SERVE_FROM_FS=1
 ```
 to avoid the caching, so that you can just Shift+Reload the pages to see the
 new content.
+{{ end }}
+
+{{ if eq $section "clone-lo" }}
+
+```bash
+git clone https://gerrit.libreoffice.org/core libreoffice
+cd libreoffice
+git checkout distro/collabora/{{.Get "lobranch"}}
+```
 {{ end }}
 
 {{ if eq $section "clone-online" }}


### PR DESCRIPTION
Before this change users couldn't see clearly, when editing the page, where are all the versions (online, core, branch). Some were in the shortcode some were in the build-code.md. Best to have it all in one place and visible from the get go (build-code.md)

Additionally: remove legacy /.autogen.sh and ./configure commands and replace it with the existing build-online section