### PR TITLE
Update chat url to matrix.org

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -59,7 +59,8 @@ type = "type"
   [params.social]
     rss = true
     email = "hello@collaboraoffice.com"
-    chat = "https://matrix.to/#/#cool-dev:clicks.codes"
+    chat = "https://matrix.to/#/#cool-dev:matrix.org"
+    chatName = "#cool-dev:matrix.org"
     facebook = "https://www.facebook.com/collaboraoffice/"
     twitter = "https://twitter.com/CollaboraOffice"
     linkedin = "https://www.linkedin.com/company/collabora-productivity-ltd/"

--- a/content/docs.md
+++ b/content/docs.md
@@ -41,7 +41,7 @@ For more detailed and pretty instructions on integrating with various partner so
 * Read the full guide on [Contributing](https://github.com/CollaboraOnline/online/blob/master/CONTRIBUTING.md)
 * Read the [Code of Conduct](https://github.com/CollaboraOnline/online/blob/master/CODE_OF_CONDUCT.md)
 * To ask questions, use the [Collabora Online forum](https://forum.collaboraonline.com)
-+ To talk with other developers please join us on [Matrix](https://matrix.to/#/#cool-dev:clicks.codes)
++ To talk with other developers please join us on {{% chat-room %}} room.
 * And feel free to share your contributions and iterations on twitter by tagging [@CollaboraOffice](https://twitter.com/CollaboraOffice) or [@CollaboraOffice@mastodon.social](https://mastodon.social/@CollaboraOffice) and using the `#cool_dev`
 
 ### Your first commit
@@ -59,7 +59,7 @@ For more detailed and pretty instructions on integrating with various partner so
 | | | |
 |-|-|-|
 | COOL Days 2021 | [Moodle Integration](https://github.com/CollaboraOnline/slides/blob/main/2021/Ash-CoolDays-2021-Dev-Moodle-Integration.pdf) |
-| COOL Days 2021 | [community website](https://github.com/CollaboraOnline/slides/blob/main/2021/pedro-silva_COOLDays-dev-2021_community-website.pdf) | 
+| COOL Days 2021 | [community website](https://github.com/CollaboraOnline/slides/blob/main/2021/pedro-silva_COOLDays-dev-2021_community-website.pdf) |
 | LibreOffice Conference 2020| [Integrating-OnLine-via-WOPI.pdf](https://speakerdeck.com/kendy/integrating-libreoffice-online-via-wopi) |
 | FOSDEM 2020 | [dialog-tunneling.pdf](https://speakerdeck.com/kendy/dialog-tunneling-in-libreoffie-online) |
 

--- a/content/post/communicate.md
+++ b/content/post/communicate.md
@@ -31,7 +31,7 @@ A great way to get in touch, ask anything or get mentoring is through one of our
 
 ## Get in touch
 * Chat on [Collabora Online forum](https://forum.collaboraonline.com/)
-* Chat via [Matrix](https://app.element.io/#/room/#cool-dev:clicks.codes)
+* Chat on {{% chat-room %}} room
 * Chat on [Telegram:CollaboraOnline](https://t.me/CollaboraOnline)
 * Send email [hello@collaboraoffice.com](mailto:hello@collaboraoffice.com)
 * Twitter [@CollaboraOffice](https://twitter.com/CollaboraOffice) feel free to use `#cool_dev` in your tweets

--- a/content/post/filebugs.md
+++ b/content/post/filebugs.md
@@ -51,8 +51,6 @@ as possible when reporting; attach a screenshot, or even a video!
 ## Ask around
 In case you have any problem reporting the bug, please don't hesitate to ask
 in the [forum](https://forum.collaboraonline.com/), or
-join the [Libera.Chat/#cool-dev channel](irc://irc.libera.chat/#cool-dev) (you
-can get there directly via a [Webchat](https://web.libera.chat/#cool-dev))
-and ask for the help there.
+join the {{% chat-room %}} room.
 
 {{< edit-button to="/content/post/filebugs.md" name="Edit page">}}

--- a/layouts/shortcodes/chat-room.html
+++ b/layouts/shortcodes/chat-room.html
@@ -1,0 +1,1 @@
+<a href="{{ .Site.Params.social.chat }}">{{ .Site.Params.social.chatName }}</a>


### PR DESCRIPTION
The matrix saga seems to be solved now

- There were 3 rooms. I needed to remove both local and published address from there the matrix.org one
- Skyler helped by setting the local address of this channel to matrix.org
- Then we could set the published and the main address as #cool-dev:matrix.org