### PR TITLE
fix(footer): Remove chatName from socials list

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -60,7 +60,6 @@ type = "type"
     rss = true
     email = "hello@collaboraoffice.com"
     chat = "https://matrix.to/#/#cool-dev:matrix.org"
-    chatName = "#cool-dev:matrix.org"
     facebook = "https://www.facebook.com/collaboraoffice/"
     twitter = "https://twitter.com/CollaboraOffice"
     linkedin = "https://www.linkedin.com/company/collabora-productivity-ltd/"

--- a/layouts/shortcodes/chat-room.html
+++ b/layouts/shortcodes/chat-room.html
@@ -1,1 +1,1 @@
-<a href="{{ .Site.Params.social.chat }}">{{ .Site.Params.social.chatName }}</a>
+<a href="{{ .Site.Params.social.chat }}">#cool-dev:matrix.org</a>


### PR DESCRIPTION
In CollaboraOnline/CollaboraOnline.github.io#119, we changed the matrix chat URL. As part of that, we added a 'chatName' parameter to the socials list. Unfortunately, this sensible-sounding solution turns out to have a flaw: the socials list is turned into the website footer, causing us to have a broken entry

![image](https://github.com/CollaboraOnline/CollaboraOnline.github.io/assets/34243578/6c6a4695-a284-48bb-8b27-902b36344a86)

Moving the single use of chatName out of that list fixes the problem