### PR TITLE
Specify a version for nodejs

### DIFF
--- a/content/post/build-code-ios.md
+++ b/content/post/build-code-ios.md
@@ -73,7 +73,7 @@ PYTHON MODULES, NODEJS, and HOMEBREW
 /usr/bin/pip3 install lxml
 ```
 
-2.1.2) Install nodejs from https://nodejs.org/en/download (macOS pkg). This package provides `npm` and `node` commands that are required to build everything in `browser/` folder.
+2.1.2) Install nodejs version 20.15.1 by downloading the macOS .pkg from the `Prebuilt installer` tab at https://nodejs.org/en/download. Note: nodejs versions newer than 20.15.1 will cause the iOS build to fail in the node-canvas package. This package provides `npm` and `node` commands that are required to build everything in `browser/` folder.
 
 2.1.3) Install Homebrew from https://github.com/Homebrew/brew/releases/latest (macOS pkg) and add /opt/homebrew/bin and /opt/homebrew/sbin to the end of your PATH.
 


### PR DESCRIPTION
At least on macOS Sequoia with Xcode 16.0 beta 3, nodejs versions newer than 20.15.1 will fail to install node-canvas during the iOS build.