### PR TITLE
feat: Update android build instructions

### DIFF
--- a/content/post/build-code-android.md
+++ b/content/post/build-code-android.md
@@ -22,72 +22,155 @@ showtitle = true
 Are you familiar with Android development environment and interested to learn more while helping the project?
 <!--more-->
 
-Head over documentation or start of by following these step-by-step instructions and build `CODE` from scratch:
+# How to build the Android app:
 
-* [Build CODE]({{< relref "build-code.md" >}} "Explore and clone GitHub repository")
-* [Build CODE for Android]({{< relref "build-code-android.md" >}} "Step-by-step setup")
+## You will need
 
+### A computer with Linux installed ## {.extraclass class="requirement-machine"}
 
 The development of the Android app has to be done on Linux, it's currently not possible to
-build the native parts on Windows. Builds have been tested with Android NDK r20b, newer NDKs may or may not work.
-Similarly to the normal CODE, you will need the following projects, cross-compiled to your target platform:
+build the native parts on Windows
 
-* LibreOffice (LOKit)
-* POCO - use [build-poco-android.sh](https://github.com/CollaboraOnline/online/blob/master/scripts/build-poco-android.sh)
-* libzstd - use [build-zstd-android.sh](https://github.com/CollaboraOnline/online/blob/master/scripts/build-zstd-android.sh)
+### The Android platform tools including a compatible NDK  ## {.extraclass class="requirement-machine"}
 
-If you want to build the full app, you need to build for 4 platforms: ARM,
-ARM64, x86 and x86-64. For development, just one of them is enough, the build
-currently defaults to ARM.
+Builds have been tested with Android NDK 23.0.7599858, other NDK versions may or
+may not work
 
-## Build LibreOffice master for Android
+### An Android or ChromeOS device or simulator ## {.extraclass class="requirement-machine"}
+
+The Android app can run in a simulator, however some bugs may be present in a
+simulator that are not present on a mobile device or vice-versa. If you are able
+to, we strongly suggest you build and run for a physical device.
+
+You should [connect this device or simulator to your computer using
+adb](https://developer.android.com/tools/adb#Enabling)
+
+## Build LibreOffice for Android
+
+### Clone LibreOffice core
+
+First, use git to clone the LibreOffice core repository from the LibreOffice
+gerrit and switch to the Collabora Online branch
+
+{{% common-build-commands section="clone-lo" lobranch="co-24.04" %}}
+
+This is the same core repository as you may already have for building Collabora
+Online. If you already have it cloned, you may [use git worktrees to speed up
+this step](https://git-scm.com/docs/git-worktree).
+
+### Configure LibreOffice core
+
+Decide what architecture you are going to build for. This will depend on your
+android device's ABI. We support building for armeabi-v7a, arm64-v8a, x86 and
+x86_64.
+
+If you're not sure what your phone's architecture is, you can either research
+online or use adb to get a list of valid architectures
+
+    $ adb shell getprop ro.product.cpu.abilist
+    arm64-v8a,armeabi-v7a,armeabi
 
 Create a file called `autogen.input` in your LibreOffice clone with the
 following content:
 
     --build=x86_64-unknown-linux-gnu
+    --with-android-ndk=/home/$USER/Android/Sdk/ndk/23.0.7599858
+    --with-android-sdk=/home/$USER/Android/Sdk
+    --enable-sal-log
+    --enable-dbgutil
+
+You also need to add a line specifying which architecture you're building for
+
+#### For arm64-v8a
+
+    --with-distro=CPAndroidAarch64
+
+#### For armeabi-v7a
+
+    --with-distro=CPAndroid
+
+#### For x86_64
+
+    --with-distro=CPAndroidX86_64
+
+#### For x86
+
+    --with-distro=CPAndroidX86
+
+---
+
+For example, if you have a device that supports `arm64-v8a` your autogen.input
+should contain this content
+
+    --build=x86_64-unknown-linux-gnu
     --with-android-ndk=/home/$USER/Android/Sdk/ndk-bundle
     --with-android-sdk=/home/$USER/Android/Sdk
-    --with-distro=CPAndroid
     --enable-sal-log
+    --with-distro=CPAndroidAarch64
+    --enable-dbgutil
 
-Then run `./autogen.sh && make`
+Finally, run
 
-## Configure the online.git
+    ./autogen.sh
 
-Don't forget to change `--with-lo-builddir` and/or path for POCO and libzstd in the following:
+### Build LibreOffice core
+
+Run `make` and wait a while for the build to finish...
+
+    make
+
+## Build Collabora Online
+
+You need a copy of `POCO` and `libzstd` built for Android in order to build the Android app. You can use these scripts to build those
+
+* POCO - use [build-poco-android.sh](https://github.com/CollaboraOnline/online/blob/master/scripts/build-poco-android.sh)
+* libzstd - use [build-zstd-android.sh](https://github.com/CollaboraOnline/online/blob/master/scripts/build-zstd-android.sh)
+
+### Configuring the build
+
+Let's set some variables based on what we just built...
+
+    export ABI=arm64-v8a
+    export POCO_DIR=/opt/android-poco
+    export ZSTD_DIR=/opt/android-zstd
+    export LO_BUILDDIR=/opt/libreoffice
+
+...remember to change your ABI to the ABI you're building the app for, POCO\_DIR and ZSTD\_DIR to the output directories of the build scripts, and LO_BUILDDIR to the directory you cloned and built LibreOffice core in.
+
+Now we can use that to configure our Collabora Online build
 
     ./autogen.sh
     ./configure --enable-androidapp \
-                --with-lo-builddir=/opt/libreoffice/master-android \
-                --with-poco-includes=/opt/android-poco/install/include \
-                --with-poco-libs=/opt/android-poco/install/armeabi-v7a/lib \
-                --with-zstd-includes=/opt/android-zstd/lib \
-                --with-zstd-libs=/opt/android-zstd/install/armeabi-v7a/lib \
-                --disable-setcap \
+                --with-lo-builddir=${LO_BUILDDIR} \
+                --with-poco-includes=${POCO_DIR}/install/include \
+                --with-poco-libs=${POCO_DIR}/install/${ABI}/lib \
+                --with-zstd-includes=${ZSTD_DIR}/lib \
+                --with-zstd-libs=${ZSTD_DIR}/install/${ABI}/lib \
                 --enable-silent-rules \
-                --enable-debug
+                --enable-debug \
+                --with-android-abi=${ABI}
+
+### Build Collabora Online
+
+Once again, after configuring the build you can run it with `make`
+
     make
-If you build for more platforms, just add more values to
---with-lo-builddir, --with-poco-includes, --with-poco-libs,
---with-zstd-includes and --with-zstd-libs delimited with `:`.
-The order must be ARM, ARM64, x86, x86-64.
 
-For example:
+## Build the android app
 
-                --with-lo-builddir=/opt/libreoffice/core_android_armeabi-v7a:/opt/libreoffice/core_android_arm64-v8a:/opt/libreoffice/core_android_x86:/opt/libreoffice/core_android_x86-64 \
-                --with-poco-includes=/opt/android-poco/install/include:/opt/android-poco/install/include:/opt/android-poco/install/include:/opt/android-poco/install/include \
-                --with-poco-libs=/opt/android-poco/install/armeabi-v7a/lib:/opt/android-poco/install/arm64-v8a/lib:/opt/android-poco/install/x86/lib:/opt/android-poco/install/x86_64/lib \
-                --with-zstd-includes=/opt/android-zstd/lib:/opt/android-zstd/lib:/opt/android-zstd/lib:/opt/android-zstd/lib \
-                --with-zstd-libs=/opt/android-zstd/install/armeabi-v7a/lib:/opt/android-zstd/install/arm64-v8a/lib:/opt/android-zstd/install/x86/lib:/opt/android-zstd/install/x86_64/lib \
+### Option 1: Using Android studio
 
+This is the recommended way to build the Android app
 
-## Build the actual app using Android Studio
+- Open Android studio
+- Open the `android` subdirectory as a project
+- Use `build -> make project` to run the build
 
-Just open Android Studio, open the `android` subdirectory as a project and
-start the build (Build -> Make Project).
+### Option 2: Using gradle from the command line
 
-Alternatively you can build from the command line:
+It may be harder to debug the app without using Android Studio. Unless you have
+prior experience with debugging Android apps outside Android Studio (or
+otherwise aren't able to use Android Studio) we recommend you follow Option 1
 
     cd android
     ./gradlew build
@@ -97,18 +180,6 @@ Alternatively you can build from the command line:
 To debug the native LibreOffice code in Android Studio, you need the debugging
 symbols and to setup Android Studio to actually read & use them.
 
-### Build debugging symbols for the modules you are interested in
-
-Add something like the following to autogen.input:
-
-    --enable-symbols="vcl/ desktop/ sal/ svx/ framework/ sfx2/ tools/ cppu/ cppuhelper/ filter/ comphelper/ Library_sw Library_swd Library_swui"
-
-clean the appropriate modules, like
-
-    make vcl.clean desktop.clean sal.clean svx.clean framework.clean sfx2.clean tools.clean cppu.clean cppuhelper.clean filter.clean comphelper.clean sw.clean
-
-and rebuild using 'make'.
-
 ### Add android/obj/local/armeabi-v7a from core.git as a Symbol Directory
 
 In Android Studio, choose Run -> Debug... -> Edit Configurations...
@@ -117,9 +188,11 @@ There go to the Android App -> app, choose the Debugger tab, and:
 
     Debug type: Auto (or Dual)
 
-Symbol Directories: here add the full path, like
+Symbol Directories: here add the full path, like...
 
-    /local/libreoffice/master-android/android/obj/local/armeabi-v7a
+    /local/libreoffice/master-android/android/obj/local/${ABI}
+
+...making sure to substitute `${ABI}` for the ABI you builts for
 
 This path contains the non-stripped version of the liblo-native-code.so, and
 the debugger will read the symbols from that one (even if the APK contains
@@ -129,7 +202,7 @@ directories - since the internal source contains stripped native code.
 Alternatively you can add the following to your ~/.lldbinit instead:
 
     settings set target.inline-breakpoint-strategy always
-    settings append target.exec-search-paths /local/libreoffice/master-android/android/obj/local/armeabi-v7a
+    settings append target.exec-search-paths /local/libreoffice/master-android/android/obj/local/${ABI}
 
 To use pretty printers for types like OUString, add the following to your
 ~/.lldbinit:
@@ -139,7 +212,7 @@ To use pretty printers for types like OUString, add the following to your
 From now on, you will be able to debug directly in the Android Studio
 debugger.  Happy debugging!
 
-## Tip: How to speed up your core.git build
+## Cross-compiling with icecream to speed up your build
 
 If you use icecream for parallel building, you can use it for
 cross-compilation too.


### PR DESCRIPTION
This is a first pass of an update. There are still some issues (e.g. the icecream section is still not architecture-agnostic) but I firmly believe it to be significantly better than what came before, which is why I've decided to push it as-is.

Apologies for the largeish commit :)

---

There were several problems with the Android build instructions which
made them sorely need an update. In no particular order, here they are:

- We didn't have instructions to build for different mobile
  architectures, but arm64-v8a is a very common architecture on modern
  Android devices
- We did have partial instructions to build for *all* architectures, but
  we didn't explain how to change your core architecture, and the vast
  majority of developers will not need to build for all architectures
- We provided very minimal instructions on everything else - presumably
  expecting you to already be a seasoned Collabora Online developer with
  good knowledge of the state of the world
- The instructions contained some outdated options (which don't exist
  anymore) and versions of things

I've expanded the instructions significantly, while also increasing
their compatibility with newer devices, and updating them to work with
modern Collabora Online

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: I7e64f7559cb9a3f1a195b0d040cca16275880fc3