### PR TITLE
build: use CFLAGS and CCFLAGS for a proper build in Fedora

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -345,7 +345,12 @@ Configure and build, adding the following configuration options to `autogen.sh` 
 ```bash
 ./autogen.sh --with-distro=CPLinux-LOKit --without-package-format
 ```
+Make sure we use unbundled libraries within POCO libraries. For this, we should export `CFLAGS` and ``CCFLAGS`` appropriately.
+
 ```bash
+export CFLAGS="$CFLAGS -DPOCO_UNBUNDLED=1"
+export CXXFLAGS="$CXXFLAGS -DPOCO_UNBUNDLED=1"
+
 make -j $(nproc)
 ```
 You can expect this process to take at least an hour or two the first time, possibly more depending on your machine and your internet connection. Subsequent builds will be faster.

--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -346,8 +346,6 @@ Configure and build, adding the following configuration options to `autogen.sh` 
 ./autogen.sh --with-distro=CPLinux-LOKit --without-package-format
 ```
 ```bash
-export CXXFLAGS="$CXXFLAGS -DPOCO_UNBUNDLED=1"
-
 make -j $(nproc)
 ```
 You can expect this process to take at least an hour or two the first time, possibly more depending on your machine and your internet connection. Subsequent builds will be faster.

--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -345,10 +345,7 @@ Configure and build, adding the following configuration options to `autogen.sh` 
 ```bash
 ./autogen.sh --with-distro=CPLinux-LOKit --without-package-format
 ```
-Make sure we use unbundled libraries within POCO libraries. For this, we should export `CFLAGS` and ``CCFLAGS`` appropriately.
-
 ```bash
-export CFLAGS="$CFLAGS -DPOCO_UNBUNDLED=1"
 export CXXFLAGS="$CXXFLAGS -DPOCO_UNBUNDLED=1"
 
 make -j $(nproc)
@@ -375,7 +372,10 @@ You can also add extra flags to customize your build:
 
 See `./configure --help` for the full list of options.
 
+Make sure we use unbundled libraries within POCO libraries. For this, we should export `CFLAGS` and ``CCFLAGS`` appropriately.
+
 ```bash
+export CFLAGS="$CFLAGS -DPOCO_UNBUNDLED=1"
 make -j `nproc`
 ```
 

--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -374,6 +374,8 @@ Make sure we use unbundled libraries within POCO libraries. For this, we should 
 
 ```bash
 export CFLAGS="$CFLAGS -DPOCO_UNBUNDLED=1"
+export CXXFLAGS="$CXXFLAGS -DPOCO_UNBUNDLED=1"
+
 make -j `nproc`
 ```
 


### PR DESCRIPTION
POCO will end up wanting to use bundled libraries in Fedora unless we use CFLAGS and CCFLAGS in Fedora. 

This commit covers the request made by @Darshan-upadhyay1110 at issue #10488. 