### PR TITLE
Fix ideas page not found

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,7 +26,7 @@ theme = "hugo-theme-chunky-poster"
   [[menu.main]]
     identifier = "ideas-page"
     name = "Ideas Page"
-    url = "/gsoc/"
+    url = "/ideas/"
     weight = 3
   [[menu.main]]
     identifier = "docs"

--- a/content/post/ideas.md
+++ b/content/post/ideas.md
@@ -6,6 +6,7 @@ home_pos = "11"
 images = [
     "beaver/ideas-copyrighted.png",
 ]
+url = "/ideas/"
 aliases = ["about-us","about-hugo","contact"]
 author = "Hugo Authors"
 +++


### PR DESCRIPTION
- after my last commit related to add new card for ideas page on home tab. The naviagtion tab option call "Ideas page" stopped working.
- this patch will fix the exact path for ideas page so it will work again.
