### PR TITLE
feat(build-code): add nix build instructions

### DIFF
--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -310,6 +310,26 @@ Now clone the forked repo:
 
 <section id="build-code-general" class="build-code-content">
 
+## Nix/NixOS {#build-code-with-nix}
+
+### What this is
+
+This is a set of shells used for development. It will let you build collabora
+from dependencies installed with Nix.
+
+### Supported platforms
+
+Currently the Nix build has only been tested on `x86_64-linux` NixOS. It would
+probably be possible to make it run on `aarch64-linux` fairly easily. It may
+also be possible to make darwin shells for building the iOS app.
+
+### How do I do it?
+
+Follow the instructions in the
+[nix-build-support](https://github.com/CollaboraOnline/nix-build-support)
+repository. They will lead you through cloning LibreOffice core and Collabora
+online, configuring your build and running your newly-built CODE.
+
 ## Build CODE & LO {#build-code-n-lo}
 
 ### Dependencies


### PR DESCRIPTION
We've had CollaboraOnline/nix-build-support for a little while but not linked to it on our docs. I've just spent some time making it nicer for people to follow and think it's now ready to be mentioned

As nix works a bit differently to other platforms, it makes sense to me that we should not give instructions here directly but should link out to our nix-build-support repo

This fixes #149