### PR TITLE
  Add Gerrit button and open external links in new tab

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -57,10 +57,13 @@
 
   </div>
 
-  <a href='https://github.com/CollaboraOnline/online'  class="btn btn-dark btn-co-secondary btn-hero">
+  <a href='https://gerrit.collaboraoffice.com/' target="_blank" class="btn btn-dark btn-co-secondary btn-hero">
+    Gerrit
+  </a>
+  <a href='https://github.com/CollaboraOnline/online' target="_blank" class="btn btn-dark btn-co-secondary btn-hero">
     GitHub
   </a>
-  <a href='https://forum.collaboraonline.com/'  class="btn btn-light btn-co-secondary btn-hero">
+  <a href='https://forum.collaboraonline.com/' target="_blank" class="btn btn-light btn-co-secondary btn-hero">
     Forum
   </a>
 </div>


### PR DESCRIPTION
  - Add a Gerrit link button before GitHub on the homepage hero section.
  - Add target="_blank" to Gerrit, GitHub, and Forum buttons so they all open in a new tab.
  
  
<img width="1750" height="843" alt="image" src="https://github.com/user-attachments/assets/472fde87-6b8b-4a2c-a0d7-18c0cfd707db" />
