### PR TITLE
Gerrit monorepo instructions update.

### DIFF
--- a/content/docs.md
+++ b/content/docs.md
@@ -34,10 +34,10 @@ For more detailed and pretty instructions on integrating with various partner so
     ownCloud
 
 ## Get involved
-* Checking out the source code to build it yourself is easy, head over to [GitHub's project page](https://github.com/CollaboraOnline/online)
+* The source lives on a single Gerrit monorepo at [gerrit.collaboraoffice.com/online](https://gerrit.collaboraoffice.com/online). The LibreOffice core sits under `engine/` inside the same repo, so there is no separate `core` clone any more.
 * After [building Collabora Online]({{< relref "build-code" >}} "How to build CODE") just do a `make run` and follow the link to tweak things live.
 * Browse the [SDK documentation](https://sdk.collaboraonline.com/) and find all about [postmessage api](https://sdk.collaboraonline.com/docs/postmessage_api.html), [integration examples](https://sdk.collaboraonline.com/docs/examples.html) and more
-* Send patches via the [GitHub pull requests](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
+* Code review now happens on [Gerrit](https://gerrit.collaboraoffice.com/), not GitHub pull requests. The [first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41) walks through SSH key setup, the `commit-msg` hook, and pushing to `refs/for/main`.
 * Read the full guide on [Contributing](https://github.com/CollaboraOnline/online/blob/main/CONTRIBUTING.md)
 * Read the [Code of Conduct](https://github.com/CollaboraOnline/online/blob/main/CODE_OF_CONDUCT.md)
 * To ask questions, use the [Collabora Online forum](https://forum.collaboraonline.com)
@@ -47,10 +47,10 @@ For more detailed and pretty instructions on integrating with various partner so
 ### Your first commit
 * First check [How to build CODE]({{< relref "build-code" >}} "How to build CODE")
 * Do your modifications and check them
-* `git commit` # to commit the stuff
+* `git commit -s` # commit, with a Signed-off-by line for the DCO
 * `git log -p -1` # to check your work
-* `git push origin HEAD:feature/name`
-* Create a Pull Request via the URL that you are told
+* `git push origin HEAD:refs/for/main` # send the patch to Gerrit for review
+* The push prints a Gerrit URL - that is your change. Reviewers leave comments there and CI votes on it.
 
 ## Watch a talk & grab slides
 

--- a/content/post/build-co-linux.md
+++ b/content/post/build-co-linux.md
@@ -107,13 +107,28 @@ Poco >= 1.12.0 is required. Some distros ship an older version -- see the [Ubunt
 
 ## Building
 
+Development happens on the unified [Gerrit monorepo](https://gerrit.collaboraoffice.com/online). The LibreOffice core sits under `engine/` inside the same `online` repo, so there is no separate `core` clone any more. Code review uses Gerrit, not GitHub pull requests; see the [first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41) for the full workflow.
+
+### Clone the monorepo
+
+For an anonymous read-only clone:
+```bash
+git clone https://gerrit.collaboraoffice.com/online collabora-online
+cd collabora-online
+```
+
+If you have a Gerrit account and plan to push changes for review, clone over SSH instead:
+```bash
+git clone ssh://YOUR_USERNAME@gerrit.collaboraoffice.com:29418/online collabora-online
+cd collabora-online
+```
+
 ### Collabora Office Core
 
-Collabora Office needs core to be built. For dependency installation, refer to https://wiki.documentfoundation.org/Development/BuildingOnLinux if needed.
+Core is the `engine/` subdirectory of the monorepo. For dependency installation, refer to https://wiki.documentfoundation.org/Development/BuildingOnLinux if needed.
 
 ```bash
-git clone --depth 1 -b main https://gerrit.collaboraoffice.com/core
-cd core
+cd engine
 ```
 
 ```bash
@@ -123,17 +138,15 @@ make
 
 > For debug builds, add `--enable-dbgutil` to the autogen line.
 
-Once done, set the path for the online build:
+Once done, record the path for the online build and step back to the top of the monorepo:
 ```bash
 export LOCOREPATH=$(pwd)
+cd ..
 ```
 
 ### Collabora Online
 
-```bash
-git clone https://github.com/CollaboraOnline/online.git collabora-online
-cd collabora-online
-```
+From the top of the `collabora-online` clone:
 
 ```bash
 ./autogen.sh

--- a/content/post/build-co-mac.md
+++ b/content/post/build-co-mac.md
@@ -85,9 +85,25 @@ it, and only depend on eg. self-built libpng, etc.
     * After that you might need to update them in System Settings > General > Software Updates
         * For some reason for me it lists both 15.3 and 16.0 there. As I have Xcode 16.0, I choose just that one.
 
+### Clone the monorepo
+
+Collabora Online and the LibreOffice core now live in a single Gerrit monorepo - core is the `engine/` subdirectory of the `online` repo, so there is no separate `core` clone any more. Code review happens on [Gerrit](https://gerrit.collaboraoffice.com/), not GitHub pull requests; see the [first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41) for the full workflow.
+
+For an anonymous read-only clone:
+```bash
+git clone https://gerrit.collaboraoffice.com/online collabora-online
+cd collabora-online
+```
+
+If you have a Gerrit account and plan to push changes for review, clone over SSH instead:
+```bash
+git clone ssh://YOUR_USERNAME@gerrit.collaboraoffice.com:29418/online collabora-online
+cd collabora-online
+```
+
 ### Build LO
 
-You need the `main` branch of Collabora Office core from gerrit.collaboraoffice.com for this, and you must use the following `autogen.input`.
+Move into the `engine/` subdirectory of the monorepo and build the `main` branch with the following `autogen.input`.
 
 NOTE: Build with stuff installed via 'brew', and not via 'lode'; if you have
 too many things installed via 'brew', compilation may fail for you due to
@@ -112,6 +128,8 @@ For dependency installation, refer to https://wiki.documentfoundation.org/Develo
 
 ### Configure Collabora Online
 
+Run this from the top of the monorepo (one level up from `engine/`):
+
     ./autogen.sh && ./configure \
     --enable-macosapp \
     --enable-experimental \
@@ -124,11 +142,11 @@ For dependency installation, refer to https://wiki.documentfoundation.org/Develo
     --with-zstd-libs=/opt/homebrew/lib \
     --with-libpng-includes=/opt/homebrew/include \
     --with-libpng-libs=/opt/homebrew/lib \
-    --with-lo-path=path-to-lo-core/instdir/your-built-lo.app \
-    --with-lokit-path=path-to-lo-core/include
+    --with-lo-path=engine/instdir/your-built-lo.app \
+    --with-lokit-path=engine/include
 
-Obviously you need to change the `path-to-lo-core` and `your-built-lo` above to
-match what you have. Also, on Intel Macs homebrew gets installed in
+Adjust `your-built-lo.app` to match the app bundle name produced by your core
+build. Also, on Intel Macs homebrew gets installed in
 `/usr/local`, not `/opt/homebrew`; but you may prefer your own built versions of
 POCO, libpng and zstd.
 

--- a/content/post/build-code-android.md
+++ b/content/post/build-code-android.md
@@ -47,16 +47,19 @@ adb](https://developer.android.com/tools/adb#Enabling)
 
 ## Build Collabora Office Core for Android
 
-### Clone Collabora Office core
+### Clone the monorepo
 
-First, use git to clone the Collabora Office core repository from
-gerrit.collaboraoffice.com and switch to the Collabora Online branch
+Collabora Online and the LibreOffice core now live in a single Gerrit monorepo - core is the `engine/` subdirectory of the `online` repo, so there is no separate `core` clone any more. Code review happens on [Gerrit](https://gerrit.collaboraoffice.com/), not GitHub pull requests; see the [first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41) for the full workflow.
+
+{{% common-build-commands section="clone-online" %}}
+
+### Move into core
+
+Core lives under `engine/` inside the monorepo - that is where you do the core build:
 
 {{% common-build-commands section="clone-lo" lobranch="main" %}}
 
-This is the same core repository as you may already have for building Collabora
-Online. If you already have it cloned, you may [use git worktrees to speed up
-this step](https://git-scm.com/docs/git-worktree).
+If you already have the monorepo cloned for another job, you may [use git worktrees to speed up this step](https://git-scm.com/docs/git-worktree).
 
 ### Configure Collabora Office core
 
@@ -135,10 +138,11 @@ Let's set some variables based on what we just built...
     export ZSTD_DIR=/opt/android-zstd
     export LO_BUILDDIR=/opt/libreoffice
 
-...remember to change your ABI to the ABI you're building the app for, POCO\_DIR and ZSTD\_DIR to the output directories of the build scripts, and LO_BUILDDIR to the directory you cloned and built Collabora Office core in.
+...remember to change your ABI to the ABI you're building the app for, POCO\_DIR and ZSTD\_DIR to the output directories of the build scripts, and LO_BUILDDIR to the `engine/` subdirectory of the monorepo where you built Collabora Office core.
 
-Now we can use that to configure our Collabora Online build
+Now step back to the top of the monorepo (one level up from `engine/`) and configure the Collabora Online build
 
+    cd ..
     ./autogen.sh
     ./configure --enable-androidapp \
                 --with-lo-builddir=${LO_BUILDDIR} \

--- a/content/post/build-code-ios.md
+++ b/content/post/build-code-ios.md
@@ -43,7 +43,23 @@ Building for `My Mac (Designed for iPad)` on Mac Silicon will run, but it is uns
 ## 1) Build the LibreOfficeKit code for iOS
 ### on a Mac ## {#ios-1-build-Lo-mac .extraclass class="requirement-machine"}
 
-1.1) First you need to build the LibreOfficeKit code (Collabora Office core) for iOS. For the build dependencies, it is the best to install [LODE, the LibreOffice Development Environment](https://wiki.documentfoundation.org/Development/lode) and add its `bin` directory to the `PATH`. Then get Collabora Office core source code and put in your autogen.input something like this:
+1.1) First you need to build the LibreOfficeKit code (Collabora Office core) for iOS. For the build dependencies, it is the best to install [LODE, the LibreOffice Development Environment](https://wiki.documentfoundation.org/Development/lode) and add its `bin` directory to the `PATH`.
+
+Collabora Online and the LibreOffice core now live in a single Gerrit monorepo - core is the `engine/` subdirectory of the `online` repo, so there is no separate `core` clone any more. Code review happens on [Gerrit](https://gerrit.collaboraoffice.com/), not GitHub pull requests; see the [first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41) for the full workflow.
+
+For an anonymous read-only clone:
+
+```bash
+git clone https://gerrit.collaboraoffice.com/online collabora-online
+```
+
+If you have a Gerrit account and plan to push changes for review, clone over SSH instead:
+
+```bash
+git clone ssh://YOUR_USERNAME@gerrit.collaboraoffice.com:29418/online collabora-online
+```
+
+Then move into `collabora-online/engine` and put in your autogen.input something like this:
 
 ```bash
 # Comment out for production builds
@@ -138,7 +154,7 @@ This will install the zstd static libraries and headers to your $HOME directory 
 
 ## 3) Build the iOS app
 ### on a Mac ## {#ios-3-clone-online-mac .extraclass class="requirement-machine"}
-3.1) Do a separate clone of the [Collabora Online repo](https://github.com/CollaboraOnline/online) on macOS.
+3.1) Step back to the top of the `collabora-online` clone (one level up from `engine/`) - the same monorepo you used in step 1 contains the online sources.
 
 Run autogen.sh, and configure it with the --enable-iosapp option:
 
@@ -153,7 +169,7 @@ Run autogen.sh, and configure it with the --enable-iosapp option:
 --with-poco-libs=$HOME/poco-ios-arm64/lib \
 --with-zstd-includes=$HOME/zstd-ios-arm64/usr/local/include \
 --with-zstd-libs=$HOME/zstd-ios-arm64/usr/local/lib \
---with-lo-builddir=/path/to/libreoffice/core
+--with-lo-builddir=$(pwd)/engine
 ```
 
 Then run:

--- a/content/post/build-code.md
+++ b/content/post/build-code.md
@@ -62,12 +62,7 @@ On top of our daily Collabora Office core archives, we have also added integrati
   * `CYPRESS_BROWSER="/usr/bin/chromium" make check` for every test or `CYPRESS_BROWSER="/usr/bin/chromium" make check-desktop spec=impress/scrolling_spec.js` for one specific test on desktop
   * More info at https://github.com/CollaboraOnline/online/blob/main/cypress_test/README
 
-* Don’t forget to fork the main repo ![|226x56](/images/forking.gif)
-* And set the remote address in .git/config to point to your fork’s address with this command:
-
-```bash
-git remote set-url origin https://github.com/PUT-YOUR-GITHUB-USERNAME-HERE/online.git
-```
+* Code review now happens on [Gerrit](https://gerrit.collaboraoffice.com/), not GitHub pull requests. When you have something to submit, follow the [first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41) to set up SSH keys, install the `commit-msg` hook, and push to `refs/for/main`.
 
 Happy hacking! : )
 
@@ -115,9 +110,8 @@ zypper in libpng16-compat-devel
 {{% common-build-commands section="code-needs-lo-wget" lotar="core-main-assets.tar.gz" %}}
 
 ### Building CODE
-You need to clone it, run autoconf/automake, configure and build using GNU make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
+Clone the unified `online` monorepo from Gerrit, run autoconf/automake, configure and build using GNU make.
 
-Now clone the forked repo:
 {{% common-build-commands section="clone-online" %}}
 
 {{% common-build-commands section="build-online" %}}
@@ -165,9 +159,8 @@ sudo dnf install \
 {{% common-build-commands section="code-needs-lo-wget" lotar="core-main-assets.tar.gz" %}}
 
 ### Building CODE
-You need to clone it, run autoconf/automake, configure and build using GNU make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
+Clone the unified `online` monorepo from Gerrit, run autoconf/automake, configure and build using GNU make.
 
-Now clone the forked repo:
 {{% common-build-commands section="clone-online" %}}
 
 {{% common-build-commands section="build-online" %}}
@@ -198,9 +191,8 @@ sudo pacman -Syu libcap libcap-ng lib32-libcap libpng poco cppunit nodejs npm ch
 {{% common-build-commands section="code-needs-lo-wget" lotar="core-main-assets.tar.gz" %}}
 
 ### Building CODE
-You need to clone it, run autoconf/automake, configure and build using GNU make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
+Clone the unified `online` monorepo from Gerrit, run autoconf/automake, configure and build using GNU make.
 
-Now clone the forked repo:
 {{% common-build-commands section="clone-online" %}}
 
 {{% common-build-commands section="build-online" %}}
@@ -243,9 +235,8 @@ sudo apt install -y libpoco-dev python3-polib libcap-dev npm \
 {{% common-build-commands section="code-needs-lo-wget" lotar="core-main-assets.tar.gz" %}}
 
 ### Building CODE
-You need to clone it, run autoconf/automake, configure and build using GNU make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
+Clone the unified `online` monorepo from Gerrit, run autoconf/automake, configure and build using GNU make.
 
-Now clone the forked repo:
 {{% common-build-commands section="clone-online" %}}
 
 {{% common-build-commands section="build-online" %}}
@@ -287,9 +278,8 @@ sudo apt install -y libpoco-dev python3-polib libcap-dev libssl-dev npm \
 {{% common-build-commands section="code-needs-lo-wget" lotar="core-main-assets.tar.gz" %}}
 
 ### Building CODE
-You need to clone it, run autoconf/automake, configure and build using GNU make. **Before moving on, [fork the repo](https://github.com/CollaboraOnline/online/fork) if you haven't done that yet.**
+Clone the unified `online` monorepo from Gerrit, run autoconf/automake, configure and build using GNU make.
 
-Now clone the forked repo:
 {{% common-build-commands section="clone-online" %}}
 
 {{% common-build-commands section="build-online" %}}
@@ -354,9 +344,13 @@ You may also want to have the following optional dependencies:
 CODE needs Collabora Office core to be built to run. You have two options to meet this requirement: either by building it locally (Option A - recommended), or by downloading a daily built archive (Option B - quick & dirty) which contains only the absolutely necessary pieces. If you are working only on the online side, without doing any code-level changes on Collabora Office core, or you just want to quickly get going to do some small fixes, you may prefer the second way.
 
 #### Option A - Build core locally (Recommended)
-A few modifications are needed in order to support building CODE with Collabora Office core. For dependency installation, refer to https://wiki.documentfoundation.org/Development/BuildingOnLinux.
+For dependency installation, refer to https://wiki.documentfoundation.org/Development/BuildingOnLinux.
 
-Clone the repository and switch to the main branch:
+First clone the unified `online` monorepo (the LibreOffice core lives under `engine/` inside this repo - there is no separate `core` clone any more):
+
+{{% common-build-commands section="clone-online" %}}
+
+Now move into the core tree and build it:
 {{% common-build-commands section="clone-lo" lobranch="main" %}}
 
 Configure and build, adding the following configuration options to `autogen.sh` or `autogen.input`:
@@ -368,16 +362,25 @@ make -j $(nproc)
 ```
 You can expect this process to take at least an hour or two the first time, possibly more depending on your machine and your internet connection. Subsequent builds will be faster.
 
+Once core is built, record its location and step back to the top of the monorepo to build online:
+```bash
+export LOCOREPATH=$(pwd)
+cd ..
+```
+
 #### Option B - Download a Daily-Built Archive of Collabora Office Core (Quick & Dirty)
 {{% common-build-commands section="code-needs-lo-wget" lotar="core-main-assets.tar.gz" %}}
 
 You should now have two new directories extracted: `instdir` and `include`. You will use the locations of these directories for the `configure` parameters in the following steps.
 
-### Building CODE
-
-You need to clone it, run autoconf/automake, configure and build using GNU make:
+When using Option B you still need the `online` checkout for the build itself - clone it now if you have not already:
 
 {{% common-build-commands section="clone-online" %}}
+
+### Building CODE
+
+Run autoconf/automake, configure and build using GNU make from the top of the `online` checkout:
+
 {{% common-build-commands section="build-online" %}}
 
 You can also add extra flags to customize your build:

--- a/content/post/faq.md
+++ b/content/post/faq.md
@@ -50,16 +50,22 @@ would love to have your help finding and fixing issues that come
 there. Checkout [how to file a bug]({{< relref "filebugs.md" >}} "How to file bugs") and put a 'Desktop:' prefix in your subject - thanks!
 
 ### Where can I get code ?
-{{< faq-date added="2025-11-26" added_commit="01ec5bb" updated="2026-04-03" updated_commit="5fc61cd" >}}
+{{< faq-date added="2025-11-26" added_commit="01ec5bb" updated="2026-04-28" updated_commit="HEAD" >}}
 
-On Dec 11, 2025 the 25.04.7.3-2 release was made from the coda-25.04.7.3-2 tags
-that exist both in core and online repo. Development continues:
-- online: main branch
-- core: main branch on gerrit.collaboraoffice.com
+The `online` and `core` repositories have been unified into a single Gerrit
+monorepo. The LibreOffice core now lives under `engine/` inside `online`, so
+there is no separate `core` clone any more. Code review has moved from GitHub
+pull requests to [Gerrit](https://gerrit.collaboraoffice.com/) - new pull
+requests opened on GitHub against `main` are auto-closed with a pointer to
+Gerrit.
 
-Repositories:
-- online: https://github.com/CollaboraOnline/online
-- core: https://gerrit.collaboraoffice.com/core
+Repository (monorepo, includes core under `engine/`):
+- anonymous HTTPS: `git clone https://gerrit.collaboraoffice.com/online`
+- Gerrit SSH (for contributors): `git clone ssh://YOUR_USERNAME@gerrit.collaboraoffice.com:29418/online`
+
+For the full Gerrit workflow (SSH key setup, `commit-msg` hook, pushing to
+`refs/for/main`, addressing review feedback) see the
+[first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41).
 
 Build instructions:
 - Linux (Collabora): https://collaboraonline.github.io/post/build-co-linux/

--- a/layouts/shortcodes/common-build-commands.md
+++ b/layouts/shortcodes/common-build-commands.md
@@ -44,18 +44,28 @@ new content.
 {{ end }}
 
 {{ if eq $section "clone-lo" }}
+Collabora Office core lives inside the `online` monorepo under `engine/`, so a separate `core` clone is no longer needed. If you have not cloned the monorepo yet, run the `clone-online` step above first. Then move into the core tree:
 
 ```bash
-git clone https://gerrit.collaboraoffice.com/core
-cd core
+cd engine
 git checkout {{.Get "lobranch"}}
 ```
 {{ end }}
 
 {{ if eq $section "clone-online" }}
+Collabora Online is hosted on Gerrit as a single monorepo. The LibreOffice core sits under `engine/` inside the same repo, so there is no separate `core` clone any more.
+
+For an anonymous read-only clone (no account needed):
 ```bash
-git clone https://github.com/YOURUSERNAME/online.git collabora-online
+git clone https://gerrit.collaboraoffice.com/online collabora-online
 ```
+
+If you have a Gerrit account and plan to push changes for review, clone over SSH instead:
+```bash
+git clone ssh://YOUR_USERNAME@gerrit.collaboraoffice.com:29418/online collabora-online
+```
+
+See the [first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41) for the full Gerrit workflow (SSH key, `commit-msg` hook, pushing to `refs/for/main`).
 
 Switch to the local clone's directory:
 ```bash
@@ -75,7 +85,7 @@ Run the generated configure script with proper parameters:
             --with-lo-path=${LOCOREPATH}/instdir \
             --enable-debug --enable-cypress
 ```
-Note: you can also add `--disable-ssl` instead of changing coolwsd.xml every time you want to disable ssl.
+Note: when building from the monorepo with core built in `engine/`, set `LOCOREPATH=$(pwd)/engine` from the top of the clone before running configure. You can also add `--disable-ssl` instead of changing coolwsd.xml every time you want to disable ssl.
 
 Start the actual build, which might take from a few minutes to half an hour (or more) depending on how powerful your machine is:
 ```bash


### PR DESCRIPTION
- Core lives at `engine/` inside the online repository.

- Use a single clone of: [https://gerrit.collaboraoffice.com/online](https://gerrit.collaboraoffice.com/online)

- Build core from the `engine/` directory.

Drop the GitHub fork workflow and direct contributors to the Gerrit first contribution guide: [https://forum.collaboraonline.com/t/your-first-pull-request/41](https://forum.collaboraonline.com/t/your-first-pull-request/41)