### PR TITLE
Add cname specifier for custom domain in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,6 +17,7 @@ jobs:
       - name: Publish Site
         uses: chabad360/hugo-gh-pages@master
         with:
+          cname: www.collaboraoffice.org
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
           args: --gc --minify --cleanDestinationDir


### PR DESCRIPTION
- Add cname field to github pages deploy workflow

This fixes the issue where a new deploy removes the custom domain from GitHub pages and causes an outage