### PR TITLE
Navbar: stack brand on two lines and remove Ideas Page tab

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xargs ls *)",
+      "Bash(git log *)",
+      "Bash(gh api *)",
+      "Bash(hugo --quiet)",
+      "Bash(curl -s -o /dev/null -w \"%{http_code}\\\\n\" https://github.com/CollaboraOnline/online/blob/main/README.CONTRIBUTING.md)",
+      "Bash(curl -s -o /dev/null -w \"master: %{http_code}\\\\n\" https://raw.githubusercontent.com/CollaboraOnline/online.mirror/master/README.CONTRIBUTING.md)",
+      "Bash(curl -s -o /dev/null -w \"main:   %{http_code}\\\\n\" https://raw.githubusercontent.com/CollaboraOnline/online.mirror/main/README.CONTRIBUTING.md)",
+      "Bash(curl -s https://api.github.com/repos/CollaboraOnline/online.mirror)",
+      "Bash(git *)"
+    ]
+  }
+}

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 baseURL = "https://CollaboraOnline.github.io"
 RelativeURLs=true
 CanonifyURLs=true
-title = "Collabora Online - Community Page"
+title = "Collabora Office - Community Page"
 copyright = "Unless a license is otherwise specified, content is under CC-BY-SA 3.0 <br> <br> Beaver illustrations are under <a href='https://github.com/CollaboraOnline/CollaboraOnline.github.io/blob/master/content/images/beaver/LICENSE'>Copyright © 2025 Collabora Ltd. All rights reserved.</a>"
 paginate = 2
 languageCode = "en"
@@ -38,11 +38,6 @@ theme = "hugo-theme-chunky-poster"
     name = "Downloads"
     url = "https://www.collaboraoffice.com/code/"
     weight = 5
-  [[menu.main]]
-    identifier = "ideas-page"
-    name = "Ideas Page"
-    url = "/ideas/"
-    weight = 6
 
 [taxonomies]
 category = "categories"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,11 @@
 {{ $current := . }}
 <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top shadow-sm" id="navbar-main-menu">
     <div class="container">
-        <a class="navbar-brand font-weight-bold" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+        <a class="navbar-brand font-weight-bold" href="{{ .Site.BaseURL }}">
+            {{ $parts := split .Site.Title " - " }}
+            <span class="brand-main">{{ index $parts 0 }}</span>
+            <span class="brand-sub">{{ index $parts 1 }}</span>
+        </a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main-menu" aria-controls="main-menu" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/static/css/header.css
+++ b/static/css/header.css
@@ -4,6 +4,27 @@
 
 .navbar-brand {
   margin-right: 0;
+  line-height: 1.1;
+}
+
+.navbar-brand .brand-main {
+  display: block;
+}
+
+.navbar-brand .brand-sub {
+  display: block;
+  margin-top: 0.2rem;
+  font-weight: 400;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+.navbar-nav .nav-link {
+  white-space: nowrap;
+}
+
+.navbar-expand-md .navbar-nav .nav-link {
+  padding-right: 1rem;
+  padding-left: 1rem;
 }
 
 .hero h3 {


### PR DESCRIPTION
- Split the brand into two stacked lines: the main title with "Community Page" beneath it as a smaller, dimmer subtitle. Both are derived from the site title (split on " - "), so the HTML <title> and RSS feeds keep the full single-line string.

- Update the site title to "Collabora Office - Community Page".

- Drop the "Ideas Page" entry from the main menu; the /ideas/ page itself is left in place.

- Keep menu links on one line (white-space: nowrap) and set their per-item padding to 1rem so all five fit on a single row at medium widths instead of wrapping.

<img width="1881" height="924" alt="image" src="https://github.com/user-attachments/assets/2108b2b1-2a3a-413f-bdae-d9cb3b957511" />
