### PR TITLE
build pages: generate them from the source repo READMEs

### DIFF
--- a/.github/workflows/sync-build-readme.yml
+++ b/.github/workflows/sync-build-readme.yml
@@ -1,0 +1,37 @@
+name: Sync build instructions from source repo
+
+# Regenerates the build-instruction pages from the build READMEs in the source
+# repository. The source repository fires a repository_dispatch when one of
+# those READMEs changes; the workflow can also be started by hand.
+
+on:
+  repository_dispatch:
+    types: [readme-sync]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout site
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GENERATE_CONTRIBUTORS }}
+
+      - name: Regenerate build pages from source READMEs
+        run: ./scripts/sync-build-readme.sh
+
+      - name: Commit and push when a page changed
+        run: |
+          git config user.name "Darshan-upadhyay1110"
+          git config user.email "darshan.upadhyay@collabora.com"
+          git add content/post/build-co-mac.md \
+                  content/post/build-co-linux.md \
+                  content/post/build-co-windows.md
+          if git diff --cached --quiet; then
+            echo "Build pages already up to date."
+            exit 0
+          fi
+          git commit -m "Sync macOS build instructions from source repo" --signoff
+          git push https://x-access-token:${{ secrets.GENERATE_CONTRIBUTORS }}@github.com/CollaboraOnline/CollaboraOnline.github.io.git HEAD:master

--- a/content/post/build-co-linux.md
+++ b/content/post/build-co-linux.md
@@ -225,6 +225,44 @@ If you just want a pre-built package instead of compiling:
 * **Flatpak** — download the **Collabora Office Linux Flatpak snapshots**:
     👉 https://www.collaboraoffice.com/downloads/Collabora-Office-Linux-Snapshot/
 
+# Release helpers
+
+`tools/add-release.py` is a script that allow adding a release to the
+appstream file prior to tagging.
+
+Usage
+
+```shell
+$ ./tools/add-release.py 25.04.7.8.1 com.collaboraoffice.Office.metainfo.xml
+```
+
+This will add release `25.04.7.8.1` with today's date in the appstream
+file `com.collaboraoffice.Office.metainfo.xml`
+
+Options are:
+
+- `-d` or `--date` to pass the date string to use.
+- `-c` or `--changelog` to use the changelog entry from a file.
+
+The expected changelog data should follow appstream `description`
+element.
+
+```xml
+<description>
+<p>Foo</p>
+<ul>
+<li>Something</li>
+</ul>
+</description>
+```
+
+# Debugging
+
+Some useful environment variable settings are `QT_LOGGING_RULES=` to always get JS console warnings
+and errors (even when running without a `--debug` command line argument) and
+`QT_MESSAGE_PATTERN=%{if-category}%{category}: %{endif}%{file}:%{line}: %{message}` to get JS
+console warnings and errors that contain file and line information.
+
 </section>
 
-{{< edit-button to="/content/post/build-co-linux.md" name="Edit page">}}
+{{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/qt/README.md" name="Edit page" >}}

--- a/content/post/build-co-mac.md
+++ b/content/post/build-co-mac.md
@@ -21,11 +21,11 @@ showimage = false
 Got a Mac and a curious mind? Build your own Collabora Office and see the magic happen.
 
 <!--more-->
+<section id="build-co-mac" class="build-co-linux">
+
 # Build Collabora Office
 
 This is the Collabora Office macOS desktop app (`macos/`).
-
-<section id="build-co-mac" class="build-co-linux">
 
 ## Requirements
 
@@ -122,4 +122,4 @@ the **TestFlight preview build**:
 
 </section>
 
-{{< edit-button to="/content/post/build-co-mac.md" name="Edit page">}}
+{{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/macos/README.md" name="Edit page" >}}

--- a/content/post/build-co-windows.md
+++ b/content/post/build-co-windows.md
@@ -21,11 +21,11 @@ showimage = false
 On Windows and want to tinker? Build Collabora Office and level up your setup.
 
 <!--more-->
+<section id="build-co-windows" class="build-co-linux">
+
 # Build Collabora Office
 
 This is the Collabora Office Windows desktop app (`windows/`).
-
-<section id="build-co-windows" class="build-co-linux">
 
 ## Requirements
 
@@ -172,4 +172,4 @@ If you just want a **pre-built snapshot for Windows**, you can download it here:
 
 </section>
 
-{{< edit-button to="/content/post/build-co-windows.md" name="Edit page">}}
+{{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/windows/coda/README.md" name="Edit page" >}}

--- a/layouts/shortcodes/edit-button.html
+++ b/layouts/shortcodes/edit-button.html
@@ -1,4 +1,8 @@
-<a href='https://github.com/CollaboraOnline/CollaboraOnline.github.io/blob/master{{ .Get "to" }}'  class="btn btn-light btn-co-secondary btn-edit-page">
+{{- $href := .Get "href" -}}
+{{- if not $href -}}
+{{- $href = printf "https://github.com/CollaboraOnline/CollaboraOnline.github.io/blob/master%s" (.Get "to") -}}
+{{- end -}}
+<a href='{{ $href }}'  class="btn btn-light btn-co-secondary btn-edit-page">
 {{ .Get "name" }}
 </a>
 <p></p>

--- a/scripts/build-headers/co-linux.header
+++ b/scripts/build-headers/co-linux.header
@@ -1,0 +1,24 @@
++++
+authors = [
+    "Collabora",
+]
+title = "Build Collabora Office for Linux"
+date = "2020-12-01"
+home_pos = "2"
+description = "Step-by-step build instructions"
+tags = [
+    "build",
+    "make",
+]
+images = [
+    "beaver/co-linux-copyrighted.png",
+]
+type = "sidebar"
+layout = "sidebar"
+showimage = false
++++
+
+Linux lover? Build Collabora Office and unleash your inner hacker.
+
+<!--more-->
+<section id="build-co-linux" class="build-co-linux">

--- a/scripts/build-headers/co-mac.header
+++ b/scripts/build-headers/co-mac.header
@@ -1,0 +1,24 @@
++++
+authors = [
+    "Collabora",
+]
+title = "Build Collabora Office for Mac"
+date = "2020-12-01"
+home_pos = "4"
+description = "Step-by-step build instructions"
+tags = [
+    "build",
+    "make",
+]
+images = [
+    "beaver/build-code-ios-copyrighted.png",
+]
+type = "sidebar"
+layout = "sidebar"
+showimage = false
++++
+
+Got a Mac and a curious mind? Build your own Collabora Office and see the magic happen.
+
+<!--more-->
+<section id="build-co-mac" class="build-co-linux">

--- a/scripts/build-headers/co-windows.header
+++ b/scripts/build-headers/co-windows.header
@@ -1,0 +1,24 @@
++++
+authors = [
+    "Collabora",
+]
+title = "Build Collabora Office for Windows"
+date = "2026-04-27"
+home_pos = "3"
+description = "Step-by-step build instructions"
+tags = [
+    "build",
+    "make",
+]
+images = [
+    "beaver/co-windows-copyrighted.png",
+]
+type = "sidebar"
+layout = "sidebar"
+showimage = false
++++
+
+On Windows and want to tinker? Build Collabora Office and level up your setup.
+
+<!--more-->
+<section id="build-co-windows" class="build-co-linux">

--- a/scripts/sync-build-readme.sh
+++ b/scripts/sync-build-readme.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Regenerate the Hugo build-instruction pages from the build READMEs in the
+# source repository. The README in the source repository is the single source
+# of truth for the build steps. For each page this script fetches the README,
+# keeps only the text between the build-doc markers, and writes a Hugo page made
+# of the page header stub, that build text, and an Edit button that links to the
+# README in the source repository. The generated pages must not be edited by
+# hand because the next run overwrites them.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Base location to read the source READMEs from. The default reads the raw files
+# from the read-only GitHub mirror of the Gerrit monorepo. Set SOURCE_BASE to a
+# "file:///absolute/path/to/online" value to generate from a local checkout when
+# testing.
+SOURCE_BASE="${SOURCE_BASE:-https://raw.githubusercontent.com/CollaboraOnline/online.mirror/main}"
+
+MARKER_START="<!-- build-doc-start -->"
+MARKER_END="<!-- build-doc-end -->"
+
+# One line per page. The fields are separated by a pipe:
+#   header stub | README path in the source repository | output page | Edit-button link
+PAGES=(
+  "scripts/build-headers/co-mac.header|macos/README.md|content/post/build-co-mac.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/macos/README.md"
+  "scripts/build-headers/co-linux.header|qt/README.md|content/post/build-co-linux.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/qt/README.md"
+  "scripts/build-headers/co-windows.header|windows/coda/README.md|content/post/build-co-windows.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/windows/coda/README.md"
+)
+
+fetch_readme() {
+  local path="$1"
+  case "$SOURCE_BASE" in
+    file://*) cat "${SOURCE_BASE#file://}/$path" ;;
+    *)        curl -fsSL "$SOURCE_BASE/$path" ;;
+  esac
+}
+
+# Print the lines that sit strictly between the start and end markers.
+extract_build_doc() {
+  awk -v start="$MARKER_START" -v end="$MARKER_END" '
+    index($0, start) { inside = 1; next }
+    index($0, end)   { inside = 0 }
+    inside           { print }
+  '
+}
+
+for entry in "${PAGES[@]}"; do
+  IFS='|' read -r header source output edit_link <<< "$entry"
+
+  readme="$(fetch_readme "$source")"
+  body="$(printf '%s\n' "$readme" | extract_build_doc)"
+
+  if [ -z "$body" ]; then
+    echo "ERROR: no build-doc markers found in $source" >&2
+    exit 1
+  fi
+
+  {
+    cat "$header"
+    printf '\n'
+    printf '%s\n' "$body"
+    printf '\n</section>\n\n'
+    printf '{{< edit-button href="%s" name="Edit page" >}}\n' "$edit_link"
+  } > "$output"
+
+  echo "Wrote $output from $source"
+done


### PR DESCRIPTION
The Linux, macOS and Windows build pages used to be edited here by hand, while the repository READMEs only pointed back to them. The same instructions lived in two places and drifted apart.

These pages are now generated from the build READMEs in the monorepo, which become the single place the instructions are kept. A sync workflow fetches each README, keeps the part between the build-doc markers, and wraps it with a per-page header stub and an Edit button that links to the README on Gerrit. The workflow runs when the source repository signals that a README changed, and can also be started by hand.

The generated pages under content/post must not be edited here, because the next sync run overwrites them.