### PR TITLE
Name the workflow with it's correct working status

### DIFF
--- a/.github/workflows/sync-build-readme.yml
+++ b/.github/workflows/sync-build-readme.yml
@@ -33,5 +33,5 @@ jobs:
             echo "Build pages already up to date."
             exit 0
           fi
-          git commit -m "Sync macOS build instructions from source repo" --signoff
+          git commit -m "Sync build instructions from source repo READMEs" --signoff
           git push https://x-access-token:${{ secrets.GENERATE_CONTRIBUTORS }}@github.com/CollaboraOnline/CollaboraOnline.github.io.git HEAD:master

--- a/content/post/build-co-linux.md
+++ b/content/post/build-co-linux.md
@@ -262,6 +262,13 @@ element.
 </description>
 ```
 
+# Debugging
+
+Some useful environment variable settings are `QT_LOGGING_RULES=` to always get JS console warnings
+and errors (even when running without a `--debug` command line argument) and
+`QT_MESSAGE_PATTERN=%{if-category}%{category}: %{endif}%{file}:%{line}: %{message}` to get JS
+console warnings and errors that contain file and line information.
+
 </section>
 
 {{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/qt/README.md" name="Edit page" >}}


### PR DESCRIPTION
The sync workflow regenerates the Linux, macOS and Windows build pages, but its name and the commit it pushed both said "macOS", which read as if only the Mac page was covered. Rename the workflow and reword the commit message it makes so they describe all three pages.