### PR TITLE
build sync: also generate the iOS and Android pages

### DIFF
--- a/.github/workflows/sync-build-readme.yml
+++ b/.github/workflows/sync-build-readme.yml
@@ -28,7 +28,9 @@ jobs:
           git config user.email "darshan.upadhyay@collabora.com"
           git add content/post/build-co-mac.md \
                   content/post/build-co-linux.md \
-                  content/post/build-co-windows.md
+                  content/post/build-co-windows.md \
+                  content/post/build-code-ios.md \
+                  content/post/build-code-android.md
           if git diff --cached --quiet; then
             echo "Build pages already up to date."
             exit 0

--- a/content/post/build-code-android.md
+++ b/content/post/build-code-android.md
@@ -36,13 +36,41 @@ These instructions build the Collabora Office app for Android. The native parts 
 
 All the source code now lives in a single Gerrit monorepo; the former Collabora Office core is the `engine/` subdirectory of the `online` repo, so there is no separate repository to clone any more. Code review happens on [Gerrit](https://gerrit.collaboraoffice.com/), not GitHub pull requests; see the [first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41) for the full workflow.
 
-{{% common-build-commands section="clone-online" clonedir="collabora-office" %}}
+Collabora Online is hosted on Gerrit as a single monorepo: all the source code lives in one repository, with the former Collabora Office core under `engine/`.
+
+For an anonymous read-only clone (no account needed):
+```bash
+git clone https://gerrit.collaboraoffice.com/online collabora-office
+```
+
+If you have a Gerrit account and plan to push changes for review, clone over SSH instead:
+```bash
+git clone ssh://YOUR_USERNAME@gerrit.collaboraoffice.com:29418/online collabora-office
+```
+
+See the [first contribution guide](https://forum.collaboraonline.com/t/your-first-pull-request/41) for the full Gerrit workflow (SSH key, `commit-msg` hook, pushing to `refs/for/main`).
+
+Switch to the local clone's directory:
+```bash
+cd collabora-office
+```
 
 ## Build the engine
 
 The engine lives under `engine/` inside the monorepo - that is where you do the engine build:
 
-{{% common-build-commands section="clone-lo" lobranch="main" %}}
+The former Collabora Office core lives inside the `online` monorepo under `engine/`, so a separate clone is no longer needed. If you have not cloned the monorepo yet, run the `clone-online` step above first. Then move into the engine tree:
+
+```bash
+cd engine
+git checkout main
+```
+
+For a localized (translated) user interface, also clone the translations repository into `engine/translations` (you are now inside `engine/`); the engine's `--with-lang` picks up the `.po` files from there:
+
+```bash
+git clone https://gerrit.collaboraoffice.com/translations translations
+```
 
 If you already have the monorepo cloned for another job, you may [use git worktrees to speed up this step](https://git-scm.com/docs/git-worktree).
 
@@ -226,4 +254,4 @@ So the result will look something like this:
     --with-distro=CPAndroid
     --enable-sal-log
 
-{{< edit-button to="/content/post/build-code-android.md" name="Edit page">}}
+{{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/android/README" name="Edit page" >}}

--- a/content/post/build-code-ios.md
+++ b/content/post/build-code-ios.md
@@ -20,6 +20,7 @@ showimage = false
 
 Are you familiar with iOS development environment and interested to learn more while helping the project?
 <!--more-->
+
 # Build the iOS app
 
 These instructions build the Collabora Office iOS app. Everything is done on a Mac: you build the engine first, then the app, from the same monorepo.
@@ -125,4 +126,4 @@ Now open the Mobile Xcode project. Xcode is very restrictive and requires some c
 
 Then build and run. Note that building for "My Mac (Designed for iPad)" on Mac Silicon will run but is unstable. You can't run in a simulator since the engine for iOS is built for arm64 only, so you can only test on a real iOS device.
 
-{{< edit-button to="/content/post/build-code-ios.md" name="Edit page">}}
+{{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/ios/README" name="Edit page" >}}

--- a/scripts/build-headers/code-android.header
+++ b/scripts/build-headers/code-android.header
@@ -1,0 +1,23 @@
++++
+authors = [
+    "Collabora",
+]
+title = "Build for Android"
+date = "2022-07-02"
+home_pos = "5"
+description = "Step-by-step build instructions"
+tags = [
+    "build",
+    "make",
+]
+images = [
+    "beaver/build-code-android-copyrighted.png",
+]
+type = "sidebar"
+layout = "sidebar"
+showimage = false
+showtitle = true
++++
+
+Are you familiar with Android development environment and interested to learn more while helping the project?
+<!--more-->

--- a/scripts/build-headers/code-ios.header
+++ b/scripts/build-headers/code-ios.header
@@ -1,0 +1,22 @@
++++
+authors = [
+    "Collabora",
+]
+title = "Build for iOS"
+date = "2023-09-01"
+home_pos = "6"
+description = "Step-by-step build instructions"
+tags = [
+    "build",
+    "make",
+]
+images = [
+    "beaver/build-code-ios-copyrighted.png",
+]
+type = "sidebar"
+layout = "sidebar"
+showimage = false
++++
+
+Are you familiar with iOS development environment and interested to learn more while helping the project?
+<!--more-->

--- a/scripts/sync-build-readme.sh
+++ b/scripts/sync-build-readme.sh
@@ -28,6 +28,8 @@ PAGES=(
   "scripts/build-headers/co-mac.header|macos/README.md|content/post/build-co-mac.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/macos/README.md"
   "scripts/build-headers/co-linux.header|qt/README.md|content/post/build-co-linux.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/qt/README.md"
   "scripts/build-headers/co-windows.header|windows/coda/README.md|content/post/build-co-windows.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/windows/coda/README.md"
+  "scripts/build-headers/code-ios.header|ios/README|content/post/build-code-ios.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/ios/README"
+  "scripts/build-headers/code-android.header|android/README|content/post/build-code-android.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/android/README"
 )
 
 fetch_readme() {
@@ -62,8 +64,12 @@ for entry in "${PAGES[@]}"; do
     cat "$header"
     printf '\n'
     printf '%s\n' "$body"
-    printf '\n</section>\n\n'
-    printf '{{< edit-button href="%s" name="Edit page" >}}\n' "$edit_link"
+    # Close the section only when the header stub opened one. The desktop pages
+    # wrap their body in a section; the iOS and Android pages do not.
+    if grep -q '<section' "$header"; then
+      printf '\n</section>\n'
+    fi
+    printf '\n{{< edit-button href="%s" name="Edit page" >}}\n' "$edit_link"
   } > "$output"
 
   echo "Wrote $output from $source"


### PR DESCRIPTION
Add header stubs and sync-table entries for iOS and Android, and commit those two pages from the workflow. Close the page section only when the header opens one, since the app pages have no section wrapper.