### PR TITLE
io repo (build-doc-sync)

### DIFF
--- a/content/post/build-code-android.md
+++ b/content/post/build-code-android.md
@@ -254,4 +254,4 @@ So the result will look something like this:
     --with-distro=CPAndroid
     --enable-sal-log
 
-{{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/android/README" name="Edit page" >}}
+{{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/android/README.md" name="Edit page" >}}

--- a/content/post/build-code-ios.md
+++ b/content/post/build-code-ios.md
@@ -126,4 +126,4 @@ Now open the Mobile Xcode project. Xcode is very restrictive and requires some c
 
 Then build and run. Note that building for "My Mac (Designed for iPad)" on Mac Silicon will run but is unstable. You can't run in a simulator since the engine for iOS is built for arm64 only, so you can only test on a real iOS device.
 
-{{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/ios/README" name="Edit page" >}}
+{{< edit-button href="https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/ios/README.md" name="Edit page" >}}

--- a/scripts/sync-build-readme.sh
+++ b/scripts/sync-build-readme.sh
@@ -28,8 +28,8 @@ PAGES=(
   "scripts/build-headers/co-mac.header|macos/README.md|content/post/build-co-mac.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/macos/README.md"
   "scripts/build-headers/co-linux.header|qt/README.md|content/post/build-co-linux.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/qt/README.md"
   "scripts/build-headers/co-windows.header|windows/coda/README.md|content/post/build-co-windows.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/windows/coda/README.md"
-  "scripts/build-headers/code-ios.header|ios/README|content/post/build-code-ios.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/ios/README"
-  "scripts/build-headers/code-android.header|android/README|content/post/build-code-android.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/android/README"
+  "scripts/build-headers/code-ios.header|ios/README.md|content/post/build-code-ios.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/ios/README.md"
+  "scripts/build-headers/code-android.header|android/README.md|content/post/build-code-android.md|https://gerrit.collaboraoffice.com/plugins/gitiles/online/+/refs/heads/main/android/README.md"
 )
 
 fetch_readme() {


### PR DESCRIPTION
Everything else is already committed. The only pending changes are exactly the rename follow-through, nothing more:
- The two app pages changed only the edit-button line (/ios/README -> /ios/README.md, same for android). Bodies untouched.
- The sync script changed only the iOS/Android source paths and edit URLs to .md.